### PR TITLE
JSAV id -> JAAL id

### DIFF
--- a/dataStructures/graph/graph.js
+++ b/dataStructures/graph/graph.js
@@ -2,10 +2,12 @@
 // Records the state of a JSAV Graph data structure
 // http://jsav.io/datastructures/graph/
 
+const jaalID = require("../jaalID");
+
 function getGraph(graph) {
   return {
     type: "graph",
-    id: graph.element[0].id,
+    id: jaalID.getJaalID(graph.element[0].id, "graph"),
     nodes: getAllNodes(graph),
     edges: getAllEdges(graph)
   }
@@ -24,12 +26,16 @@ function getEdge(edge) {
   if (typeof(w) === "undefined") {
     w = 0;
   }
+  const startnode = getNode(edge.startnode).id;
+  const endnode = getNode(edge.endnode).id
   return {
     // list of CSS classes, e.g. ["jsavedge", "marked"]
     classList: edge.element[0].classList,
-
-    startNode: getNode(edge.startnode),
-    endNode: getNode(edge.endnode),
+    // JAAL id constructed from "${startnode}${endnode}"
+    // as JSAV does not give edges an id.
+    id: jaalID.getJaalID(startnode + endnode, "edge"),
+    startNode: startnode,
+    endNode: endnode,
     weight: edge.weight()
   }
 }
@@ -45,8 +51,8 @@ function getNode(node) {
     // data type of value label, e.g. "string"
     valueType: node.element[0].dataset.valueType,
 
-    // JSAV id of the node, e.g. "jsav-f09280868518460087f04b92138fd452"
-    id: node.element[0].id,
+    // JAAL id of the node, mapped to JSAV id
+    id: jaalID.getJaalID(node.element[0].id, "node"),
   }
 }
 

--- a/dataStructures/jaalID.js
+++ b/dataStructures/jaalID.js
@@ -1,0 +1,46 @@
+/**
+ * jaalID.js
+ * 
+ * Functionality to convert JSAV ID to human-readable JAAL IDs. 
+ */
+
+
+// Map to store the JSAV ID to JAAL ID mappings
+const jsavToJaalID = new Map();
+// Object to store the next id to hand out for each of the types.
+// ids are handed out consecutively for ease of reading.
+const ids = {
+    "edge" : 1,
+    "graph" : 1,
+    "keyvalue": 1,
+    "matrix": 1,
+    "node": 1
+}
+// List of accepted types in JAAL 1.1 that have an id derived from the name
+const acceptedTypes = ["edge", "graph", "keyvalue", "matrix", "node"];
+
+/**
+ * Function to convert the JSAV-generated IDs into human-readable JAAL IDs. 
+ * @param jsavID is the JSAV-generated ID. 
+ * @param type should be one of the acceptedTypes above. 
+ * @returns human-readable JAAL ID in the format {type + number}. 
+ */
+function getJaalID (jsavID, type) {
+    jaalID = jsavToJaalID.get(jsavID); 
+
+    if (jaalID === undefined) {
+        if (type === undefined || !acceptedTypes.includes(type)) {
+            console.warn("Trying to create JAAL ID, but type", type, 
+                         "is not one of", acceptedTypes);
+            return;
+        }
+        jaalID = type + ids[type];
+        ids[type] += 1;
+        jsavToJaalID.set(jsavID, jaalID);
+    } 
+    return jaalID;
+}
+
+module.exports = {
+    getJaalID
+}

--- a/metadata/metadata.js
+++ b/metadata/metadata.js
@@ -11,7 +11,7 @@ function setExerciseMetadata(metadata) {
   metadata.windowLocation = window.location.href.split('?')[0];
   const d = new Date();
   metadata.recordingStarted = d.toISOString();
-  metadata.recordingTimezone = d.getTimezoneOffset() / 60; // hours to UTC
+  metadata.recordingTimezone = -1 * d.getTimezoneOffset() / 60; // hours to UTC
   return submission.addStandardMetadata(metadata);
 }
 


### PR DESCRIPTION

Fulfil #6 . 

jaalID.js implements functionality to map from JSAV id to JAAL id for the different JAAL types. 
graph.js adapted to using JAAL ids, and to give edges ids. 

Other jsav data structures are not yet converted to JAAL ids. 