### PR TITLE
Unit testing for JAAL 1.1 node

### DIFF
--- a/__test__/jaalID.test.js
+++ b/__test__/jaalID.test.js
@@ -1,0 +1,82 @@
+/**
+ * Test suite for the dataStructures/jaalID.js file. 
+ */
+const jaalID = require("../dataStructures/jaalID"); 
+
+
+/**
+ * Function to test the basic JAAL types. 
+ */
+describe("Basic JAAL types", () => {
+    test("Edge", () => {
+        expect(jaalID.getJaalID("e1", "edge")).toBe("edge1");
+    })
+    
+    test("Graph", () => {
+        expect(jaalID.getJaalID("g1", "graph")).toBe("graph1");
+    })
+
+    test("Node", () => {
+        expect(jaalID.getJaalID("n1", "node")).toBe("node1");
+    })
+
+    test("Matrix", () => {
+        expect(jaalID.getJaalID("m1", "matrix")).toBe("matrix1");
+    })
+
+    test("Keyvalue", () => {
+        expect(jaalID.getJaalID("k1", "keyvalue")).toBe("keyvalue1");
+    })
+    
+})
+
+/**
+ * Tests to make sure that the right returns are given when the types
+ * are wrong. 
+ */
+describe("Wrong JAAL types", ()=> {
+    // Nonexistent JAAL type
+    test("Nonexistent JAAL type", () => {
+        expect(jaalID.getJaalID("baa", "vertex")).toBeUndefined();
+    })
+
+    // Set an edge with edge type, then call it again with node/vertex
+    // This should return edge, as type is not checked if it is 
+    // a known jsav id. 
+    test("Known edge id, wrong type", () => {
+        expect(jaalID.getJaalID("e1", "edge")).toBe("edge1");
+        expect(jaalID.getJaalID("e1", "node")).toBe("edge1");
+        expect(jaalID.getJaalID("e1", "vertex")).toBe("edge1");
+    })
+
+    // Missing JAAL type for unknown jsav-id
+    test("Mising type", () => {
+        expect(jaalID.getJaalID("unknown-jaal-id")).toBeUndefined();
+    })
+})
+
+/**
+ * Tests to make sure that it still works when there are multiple calls
+ */
+describe("Multiple jaalID calls", () => {
+    //Set jaal ID then fetch it again. 
+    test("Get known edge", () => {
+        expect(jaalID.getJaalID("e1", "edge")).toBe("edge1");
+        expect(jaalID.getJaalID("e1")).toBe("edge1");
+    })
+
+    //Make sure that the counter increments correctly. 
+    test("Multiple edges", ()=> {
+        for(var i = 1; i <= 10; i++) {
+            expect(jaalID.getJaalID("e"+i, "edge")).toBe("edge"+i);
+        }
+        
+    })
+
+    //Makre sure that incrementing works correctly when mixing type calls
+    test("Mixed types", () => {
+        expect(jaalID.getJaalID("n1", "node")).toBe("node1");
+        expect(jaalID.getJaalID("m1", "matrix")).toBe("matrix1");
+        expect(jaalID.getJaalID("n2", "node")).toBe("node2");
+    })
+})

--- a/__test__/jest_notes.md
+++ b/__test__/jest_notes.md
@@ -1,0 +1,64 @@
+## Running tests
+
+```npm test```
+
+or 
+
+```npm run test``` 
+
+
+Jest requires tests to be in a folder `__test__` in the same folder as package.json.
+
+Jest files need to have the `.test.js` extension. 
+
+
+Basic syntax: 
+```js
+test("test case name", () => {
+    expect(something).toBe(expected_value);
+})
+```
+
+You can group test cases into a collection. Each block can have set-ups specific to that block. Environment seems to be reset between describe blocks, but cannot say for sure. 
+
+```js
+describe("test block description", () => {
+    test("test case name", () => {
+        expect(something).toBe(expected_value);
+    })
+})
+```
+
+Set-up and tear-down can be done between tests, but also at the start/end of a test-block. 
+
+```js
+afterAll(() => {
+    // do something after all tests
+})
+afterEach(() => {
+    // do something after every individual test
+})
+beforeAll(() => {
+    // do something before all tests
+})
+beforeEach(() => {
+    // do something before every individual test. 
+})
+```
+if you only want to run a few tests out of a file, specify them with `test.only()`. If you want to skip a specific test: `test.skip()`. Can write test functions already with `test.todo()`, it'll highlight that you still need to do these. 
+
+
+For functions that return objects: 
+
+`expect.toHaveProperty('property name')` to check if a property is present. Can pass a second parameter to check if property is a specific value or type. To check if correct type: `expect.toHaveProperty('property name', expect.any(Type))`. 
+
+To check if an object returned is the expected object: `expect.toMatchObject({Obj})`. 
+
+
+## Jest documentation
+
+https://jestjs.io/docs/getting-started
+
+## Jest cheatsheet
+
+https://devhints.io/jest

--- a/__test__/node.test.js
+++ b/__test__/node.test.js
@@ -1,0 +1,51 @@
+/**
+ * Tests for the node function as used in graph.js
+ */
+const graph = require("../dataStructures/graph/graph")
+const helper = require("./testHelpers")
+
+/**
+ * Initialise a node with minial values. Node's format: 
+ * const node = {
+ *    element : [{
+ *        dataset: {
+ *            value: ""
+ *        }, 
+ *        id: ""
+ *    }]
+ * } 
+ */
+const node = helper.node
+node.element[0].dataset.value = 0;
+node.element[0].dataset.id = "jsav-id";
+
+/**
+ * Basic test to see if we get back the expected node object. 
+ */
+test("Basic node test", () => {
+    console.log(graph.getNode(node));
+    expect(graph.getNode(node)).toMatchObject({key: '0', id: 'node1'});
+})
+
+/**
+ * Test to check that the required properties are present in the node.
+ */
+test("Node object containing minimal required fields", () => {
+    expect(graph.getNode(node)).toHaveProperty('id');
+
+    expect(graph.getNode(node)).toHaveProperty('key');
+})
+
+/**
+ * Test to make sure that the id field contains a string (JAAL 1.1)
+ */
+test("Id field is a string", () => {
+    expect(graph.getNode(node)).toHaveProperty('id', expect.any(String));
+})
+
+/**
+ * Test to make sure that the key field contains a string (JAAL 1.1)
+ */
+test("Key field is a string", () => {
+    expect(graph.getNode(node)).toHaveProperty('key', expect.any(String));
+})

--- a/__test__/node.test.js
+++ b/__test__/node.test.js
@@ -5,19 +5,16 @@ const graph = require("../dataStructures/graph/graph")
 const helper = require("./testHelpers")
 
 /**
- * Initialise a node with minial values. Node's format: 
- * const node = {
- *    element : [{
- *        dataset: {
- *            value: ""
- *        }, 
- *        id: ""
- *    }]
- * } 
+ * Minimal data structure as gathered from the JSAV dump for a node.
  */
-const node = helper.node
-node.element[0].dataset.value = 0;
-node.element[0].dataset.id = "jsav-id";
+ const node = {
+    element : [{
+        dataset: {
+            value: 0
+        }, 
+        id: "jsav-id"
+    }]
+  }
 
 /**
  * Basic test to see if we get back the expected node object. 

--- a/__test__/testHelpers.js
+++ b/__test__/testHelpers.js
@@ -258,21 +258,9 @@ function arraySwap(arr, i, j) {
   return newArr;
 }
 
-/**
- * Minimal data structure as gathered from the JSAV dump for a node.
- */
-const node = {
-  element : [{
-      dataset: {
-          value: ""
-      }, 
-      id: ""
-  }]
-}
 
 module.exports = {
   exercise,
-  node, 
   singleArray,
   multipleArrays,
   jsavInitEvent,

--- a/__test__/testHelpers.js
+++ b/__test__/testHelpers.js
@@ -258,8 +258,21 @@ function arraySwap(arr, i, j) {
   return newArr;
 }
 
+/**
+ * Minimal data structure as gathered from the JSAV dump for a node.
+ */
+const node = {
+  element : [{
+      dataset: {
+          value: ""
+      }, 
+      id: ""
+  }]
+}
+
 module.exports = {
   exercise,
+  node, 
   singleArray,
   multipleArrays,
   jsavInitEvent,

--- a/dataStructures/graph/graph.js
+++ b/dataStructures/graph/graph.js
@@ -49,7 +49,7 @@ function getNode(node) {
     // classList: node.element[0].classList,
 
     // label of the node, e.g. "A"
-    key: node.element[0].dataset.value,
+    key: String(node.element[0].dataset.value),
 
     // JAAL id of the node, mapped to JSAV id
     id: jaalID.getJaalID(node.element[0].id, "node"),
@@ -59,5 +59,6 @@ function getNode(node) {
 module.exports = {
   getGraph,
   nodes: getAllNodes,
-  edges: getAllEdges
+  edges: getAllEdges,
+  getNode,
 }


### PR DESCRIPTION
Fulfil #8 :
jaalID.test.js: Add unit tests for /dataStructures/jaalID.js .
node.test.js: Add unit tests for `getNode(node)` function from /dataStructures/graph/graph.js
testHelpers.js: Add minimal data structure for nodes.
jest_notes.md: Notes on using jest.
graph.js: Fix bug where key could be non-string. Export getNode function for testing.