### PR TITLE
graph.js: Node and edge style

### DIFF
--- a/__test__/node.test.js
+++ b/__test__/node.test.js
@@ -1,4 +1,10 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The above comment is required at the top of the file to set the 
+ * jest environment to allow the creation of DOM elements.
  * Tests for the node function as used in graph.js
  */
 const graph = require("../dataStructures/graph/graph")
@@ -6,13 +12,18 @@ const helper = require("./testHelpers")
 
 /**
  * Minimal data structure as gathered from the JSAV dump for a node.
+ * First create a dom_node so that we can have a DOMTokenList for the classes.
  */
+  const dom_node = document.createElement("div");
+  dom_node.classList.add("marked");
+
  const node = {
     element : [{
         dataset: {
             value: 0
         }, 
-        id: "jsav-id"
+        id: "jsav-id",
+        classList: dom_node.classList
     }]
   }
 
@@ -20,8 +31,7 @@ const helper = require("./testHelpers")
  * Basic test to see if we get back the expected node object. 
  */
 test("Basic node test", () => {
-    console.log(graph.getNode(node));
-    expect(graph.getNode(node)).toMatchObject({key: '0', id: 'node1'});
+    expect(graph.getNode(node)).toMatchObject({style: "visited", key: '0', id: 'node1'});
 })
 
 /**
@@ -45,4 +55,17 @@ test("Id field is a string", () => {
  */
 test("Key field is a string", () => {
     expect(graph.getNode(node)).toHaveProperty('key', expect.any(String));
+})
+
+/**
+ * Tests to make sure that the style is set properly. 
+ */
+test("Style is visited", () => {
+    expect(graph.getNode(node)).toHaveProperty('style', 'visited');
+})
+
+test("Style is unvisited", () => {
+    dom_node.classList.remove("marked");
+    node.element[0].classList = dom_node.classList;
+    expect(graph.getNode(node)).toHaveProperty('style', 'unvisited');
 })

--- a/dataStructures/graph/graph.js
+++ b/dataStructures/graph/graph.js
@@ -31,10 +31,10 @@ function getEdge(edge) {
     w = 0;
   }
   const startnode = getNode(edge.startnode).id;
-  const endnode = getNode(edge.endnode).id
+  const endnode = getNode(edge.endnode).id;
+  const classes = edge.element[0].classList;
   return {
-    // list of CSS classes, e.g. ["jsavedge", "marked"]
-    // classList: edge.element[0].classList,
+    style: classes.contains("marked") ? "selected" : "unselected",
     // JAAL id constructed from "${startnode}${endnode}"
     // as JSAV does not give edges an id.
     id: jaalID.getJaalID(startnode + endnode, "edge"),
@@ -44,10 +44,12 @@ function getEdge(edge) {
 }
 
 function getNode(node) {
+  // list of CSS classes, e.g. ["jsavnode", "jsavgraphnode", "marked"]
+  const classes = node.element[0].classList;
   return {
-    // list of CSS classes, e.g. ["jsavnode", "jsavgraphnode", "marked"]
-    // classList: node.element[0].classList,
-
+    // Check for the presence of marked in the class list. 
+    // If present, node is visited.
+    style: classes.contains("marked") ? "visited" : "unvisited",
     // label of the node, e.g. "A"
     key: String(node.element[0].dataset.value),
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "Giacomo Mariani, Artturi Tilanterä, and Johanna Sänger",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^28.1.0"
+    "jest": "^28.1.0",
+    "jest-environment-jsdom": "^28.1.0"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
Fulfil issue #10 and #13 . 

graph.js: Add style tags of "visited" or "unvisited" to the nodes as per jaal-dijkstra-student.json.
graph.js: Add style tags of "selected" or "unselected" to the edges as per jaal-dijkstra-student.json.

Update `node.test.js` to facilitate the style tags and write 2 test cases for this.

node.test.js: create dom_node with a classList, add this to the node. Add jsdom as jest-environment to be able to create the dom_node.
package.json: add jest-environment-jsdom as devDependency, required for the node.test.js file.

Tests are passing, ran with `npm test`.