### PR TITLE
Add JAAL1.1 Validation

### DIFF
--- a/exerciseRecorder.js
+++ b/exerciseRecorder.js
@@ -11,6 +11,7 @@ const metad_func = require('./metadata/metadata');
 const def_func = require('./definitions/definitions');
 const init_state_func = require('./initialState/initialState');
 const anim_func = require('./animation/animation');
+const validator_func = require('./validation/validator');
 
 // Services module is not needed, because OpenDSA code will handle the
 // communication to A+ LMS through mooc-grader.
@@ -270,6 +271,6 @@ function finish(eventData) {
 // Finishes the recording without saving the model answer.
 function finishWithoutModelAnswer(eventData) {
   def_func.setFinalGrade(eventData);
-
+  validator_func.validateData(submission.state());
   JSAVrecorder.sendSubmission(submission.state())
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jest": "^28.1.0"
   },
   "dependencies": {
+    "ajv": "^8.11.0",
     "axios": "^0.21.1",
     "browserify": "^17.0.0",
     "genversion": "^3.0.2",

--- a/validation/schemas/definitions.json
+++ b/validation/schemas/definitions.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/definitions.json",
+  "title": "JAAL 1.1 definitions",
+  "description": "Style definitions for the exercise",
+  "type": "object",
+  "properties": {
+    "styles": {
+      "description": "Array of style definitions.",
+      "type": "array",
+      "items": {
+        "$ref": "style.json"
+      }
+    },
+    "score": {
+      "description": "Grading data of the exercise.",
+      "type": "object",
+      "properties": {
+        "modelSteps": {
+          "description": "Number of steps in the model answer.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "studentSteps": {
+          "description": "The total number of steps the student has performed.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "correctSteps": {
+          "description": "Number of student's consecutive correct steps from the beginning, counted by automatic grader of the exercise.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "undoSteps": {
+          "description": "Number of Undo actions",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": ["modelSteps", "studentSteps", "correctSteps", "undoSteps"]
+    },
+    "modelAnswer": {
+      "description": "Steps of the model answer.",
+      "type": "array",
+      "items": {
+        "$ref": "event.json"
+      }
+    }
+  },
+  "required": ["styles", "score", "modelAnswer"]
+}

--- a/validation/schemas/edge.json
+++ b/validation/schemas/edge.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/edge.json",
+  "title": "JAAL 1.1 edge",
+  "description": "A graph edge in a JAAL recording.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A unique identifier for the node among all data structures.",
+      "type": "string",
+      "pattern": "^edge"
+    },
+    "node": {
+      "description": "A graph edge is defined by two nodes. If the graph is directed, the first node is the source and the second node is the target.",
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "string",
+        "pattern": "^node"
+      }
+    },
+    "style": {
+      "description": "Graphical style of the node: a name of a style definition.",
+      "type": "string"
+    },
+    "tag": {
+      "description": "Text displayed in the middle of the edge. E.g. name or weight of the edge.",
+      "type": "string"
+    },
+    "tailElem": {
+      "description": "Data element at the tail (start) node of the edge.",
+      "type": "string"
+    },
+    "headElem": {
+      "description": "Data element at the head (end) node of the edge.",
+      "type": "string"
+    }
+  },
+  "required": ["id", "node"]
+}

--- a/validation/schemas/event.json
+++ b/validation/schemas/event.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/event.json",
+  "title": "JAAL 1.1 event",
+  "description": "An event in JAAL 1.1 recording. An event is a time-dependent user action.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "The type of the event",
+      "type": "string",
+      "pattern": "^click|grade|undo|operation|narration$"
+    },
+    "time": {
+      "description": "A time in milliseconds from the start of the simulation.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "object": {
+      "description": "Reference to a JAAL data structure or the Undo button.",
+      "type": "string",
+      "pattern": "^edge|graph|keyvalue|matrix|node"
+    }
+  },
+  "if": {
+    "properties": { "type": { "const": "click" } }
+  },
+  "then": {
+    "required": ["object", "time", "type"]
+  },
+  "else": {
+    "required": ["time", "type"]
+  }
+}

--- a/validation/schemas/graph.json
+++ b/validation/schemas/graph.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/graph.json",
+  "title": "JAAL 1.1 graph",
+  "description": "A graph data structure for representing lists, trees, and graphs.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A unique identifier for the graph among all data structures.",
+      "type": "string",
+      "pattern": "^graph"
+    },
+    "node": {
+      "description": "List of nodes in the graph.",
+      "type": "array",
+      "items": {
+        "$ref": "node.json"
+      }
+    },
+    "edge": {
+      "description": "List of edges in the graph.",
+      "type": "array",
+      "items": {
+        "$ref": "edge.json"
+      }
+    },
+    "directed": {
+      "description": "Directedness of the graph.",
+      "type": "boolean"
+    },
+    "root": {
+      "description": "Indicates the root node, if the graph is a rooted tree.",
+      "type": "string",
+      "pattern": "^node"
+    },
+    "dsClass": {
+      "description": "A keyword describing the main interpretation of the graph",
+      "type": "string",
+      "enum": ["list", "tree", "graph"]
+    },
+    "dsSubClass": {
+      "description": "A free keyword descriping the detailed interpretation of the graph.",
+      "type": "string"
+    },
+    "legend": {
+      "description": "A text to be displayed on the top of the graph.",
+      "type": "string"
+    },
+    "style": {
+      "description": "Graphical style of the node: a name of a style definition.",
+      "type": "string"
+    }
+  },
+  "required": ["id", "node", "edge", "directed", "dsClass"]
+}

--- a/validation/schemas/initialState.json
+++ b/validation/schemas/initialState.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/initialState.json",
+  "title": "JAAL 1.1 definitions",
+  "description": "Initial state for the exercise",
+  "type": "object",
+  "properties": {
+    "dataStructures": {
+      "description": "Initial data structures for the exercise.",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "$ref": "graph.json" },
+          { "$ref": "matrix.json" },
+          { "$ref": "node.json" }
+        ]
+      }
+    }
+  },
+  "required": ["dataStructures"]
+}

--- a/validation/schemas/jaal.json
+++ b/validation/schemas/jaal.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/jaal.json",
+  "title": "JAAL 1.1",
+  "description": "JSON-based algorithm animation language",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "$ref": "metadata.json"
+    },
+    "definitions": {
+      "description": "Definitions: style and model answer",
+      "$ref": "definitions.json"
+    },
+    "initialState": {
+      "description": "Initial state of data structures",
+      "$ref": "initialState.json"
+    },
+    "animation": {
+      "description": "Student's trace as algorithm animation",
+      "type": "array",
+      "items": {
+        "$ref": "event.json"
+      }
+    }
+  },
+  "required": [ "metadata", "definitions", "initialState", "animation" ]
+}

--- a/validation/schemas/keyvalue.json
+++ b/validation/schemas/keyvalue.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/keyvalue.json",
+  "title": "JAAL 1.1 key-value pair",
+  "description": "A key which points to a value.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A unique identifier for the node among all data structures.",
+      "type": "string",
+      "pattern": "^keyvalue"
+    },
+    "key": {
+      "description": "Key part of the key-value pair. If the type is string, it may also be an identifier of a graph, matrix, or node defined elsewhere.",
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "graph.json" },
+        { "$ref": "matrix.json" },
+        { "$ref": "node.json" }
+      ]
+    },
+    "value": {
+      "description": "Value part of the key-value pair. If the type is string, it may also be an identifier of a graph, matrix, or node defined elsewhere.",
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "graph.json" },
+        { "$ref": "matrix.json" },
+        { "$ref": "node.json" }
+      ]
+    }
+  },
+  "required": ["id", "key", "value"]
+}

--- a/validation/schemas/matrix.json
+++ b/validation/schemas/matrix.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/matrix.json",
+  "title": "JAAL 1.1 matrix",
+  "description": "A one- or two-dimensional array with fixed number of rows and columns.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A unique identifier for the matrix among all data structures.",
+      "type": "string",
+      "pattern": "^matrix"
+    },
+    "rows": {
+      "description": "Number of rows in the matrix.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "columns": {
+      "description": "Number of columns in the matrix.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "key": {
+      "description": "List of rows in the array.",
+      "type": "array",
+      "items": {
+        "description": "List of cells on a row.",
+        "type": "array",
+        "items": {
+          "$ref": "node.json"
+        }
+      }
+    },
+    "rowLabels": {
+      "description": "Label for each row to be displayed on the bottom of the matrix.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "columnLabels": {
+      "description": "Label for each column to be displayed on the bottom of the matrix.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "legend": {
+      "description": "A text to be displayed on the top of the matrix.",
+      "type": "string"
+    },
+    "style": {
+      "description": "Graphical style of the node: a name of a style definition.",
+      "type": "string"
+    }
+  },
+  "required": ["id", "rows", "columns", "key"]
+}

--- a/validation/schemas/metadata.json
+++ b/validation/schemas/metadata.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/metadata.json",
+  "title": "JAAL 1.1 metadata",
+  "description": "Metadata about a JAAL recording",
+  "type": "object",
+  "properties": {
+    "jaalVersion": {
+      "description": "Text 'JAAL' with a language version number",
+      "type": "string"
+    },
+    "jaalGenerator": {
+      "description": "JAAL data generator software name and version",
+      "type": "string"
+    },
+    "browser": {
+      "description": "Name and version of the web browser which is running JAAL data generator software",
+      "type": "string"
+    },
+    "exercise": {
+      "description": "Information about the VAS exercise",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the exercise",
+          "type": "string"
+        },
+        "collection": {
+          "description": "Name of the exercise collection (e.g. the name of an electronic textbook)",
+          "type": "string"
+        },
+        "runningLocation": {
+          "description": "URL of the configured and running exercise",
+          "type": "string"
+        }
+      },
+      "required": [ "name", "collection" ]
+    },
+    "simulationStart": {
+      "description": "A timestamp: when the exercise is loaded and the JAAL recorder begins recording. A time stamp in ISO 8601 format: YYYY-MM-DDTHH:mm:ss.sssZ",
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+    }
+  },
+  "required": [ "jaalVersion", "jaalGenerator", "exercise" ]
+}

--- a/validation/schemas/node.json
+++ b/validation/schemas/node.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/node.json",
+  "title": "JAAL 1.1 node",
+  "description": "Generic data structure for an array cell, a list node, a tree node, and a graph node.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A unique identifier for the node among all data structures.",
+      "type": "string",
+      "pattern": "^node"
+    },
+    "key": {
+      "description": "Primary data inside the node. If the type is string, it may also be an identifier of a graph, matrix, or node defined elsewhere.",
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "keyvalue.json" },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "keyvalue.json"
+          }
+        }
+      ]
+    },
+    "legend": {
+      "description": "A text to be displayed aside the node.",
+      "type": "string"
+    },
+    "style": {
+      "description": "Graphical style of the node: a name of a style definition.",
+      "type": "string"
+    }
+  },
+  "required": ["id", "key"]
+}

--- a/validation/schemas/style.json
+++ b/validation/schemas/style.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jaal.fi/schemas/style.json",
+  "title": "JAAL 1.1 node",
+  "description": "A style definition in a JAAL recording.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "A unique identifier for the style among all styles.",
+      "type": "string",
+      "minLength": 3
+    },
+    "text-color": {
+      "description": "Color for the text inside the element.",
+      "$ref": "#/definitions/hexcolor"
+    },
+    "fill-color": {
+      "description": "Fill color for the inside area of the element.",
+      "$ref": "#/definitions/hexcolor"
+    },
+    "border-color": {
+      "description": "Border color for the outline of the element.",
+      "$ref": "#/definitions/hexcolor"
+    }
+  },
+  "definitions": {
+    "hexcolor": {
+      "description": "RGB color triplet:  #rrggbb, where each rr, gg, and bb are red-green-blue values in the range 0..255 in hexadecimal.",
+      "type": "string",
+      "pattern": "^#([0-9]|[a-f]){6}$"
+    }
+  }
+}

--- a/validation/update-schemas.sh
+++ b/validation/update-schemas.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# A quick and dirty script to update the schema files. 
+# It assumes that JAAL is in the same folder as jsav-exercise-recorder
+cp ../../JAAL/spec/schemas/* schemas/

--- a/validation/validator.js
+++ b/validation/validator.js
@@ -1,0 +1,44 @@
+/**
+ * Use AJV to validate the data against the JAAL 1.1 schema before 
+ * it is sent off to the server. 
+ *
+ * JAAL 1.1 is written in 2020-12 draft. 
+ * schemas/jaal.json is dependent on all the other json-files
+ * in the schemas folder. 
+ */
+const Ajv2020 = require("ajv/dist/2020")
+const schemaDependencies = [require("./schemas/definitions.json"), 
+                            require("./schemas/edge.json"), 
+                            require("./schemas/event.json"), 
+                            require("./schemas/graph.json"), 
+                            require("./schemas/initialState.json"), 
+                            require("./schemas/keyvalue.json"), 
+                            require("./schemas/matrix.json"), 
+                            require("./schemas/metadata.json"), 
+                            require("./schemas/node.json"), 
+                            require("./schemas/style.json")];
+
+
+/**
+ * validateData validates the parameter data against JAAL1.1. 
+ * If the data is not valid, it prints all the validation errors to the console.
+ * @param data is a JSON object of the data to be submitted to the server.
+ * @returns whether the data is valid JAAL1.1
+ */
+function validateData (data) {
+    //Set allErrors to true, otherwise we only get one error at a time.
+    const ajv = new Ajv2020({allErrors: true});
+    const validate = ajv.addSchema(schemaDependencies)
+                        .compile(require("./schemas/jaal.json"));
+    
+    const validation_passed = validate(data);
+    if (!validation_passed) {
+        console.log("Data is not valid JAAL1.1 schema.");
+        console.log(validate.errors);
+    }
+    return validation_passed;
+}
+
+module.exports = {
+    validateData
+}


### PR DESCRIPTION
Fulfil #20 .

Update:
`package.json`: add ajv as a dependency
`exerciseRecorder.js`: require the new `validator.js` file and call its validate  function before the data is submitted.

Add:
`validation/schema/*`: JAAL 1.1 schema files from https://github.com/Aalto-LeTech/JAAL/tree/main/spec/schemas .
`validation/update-schemas.sh`: A bash script to update the JAAL schemas. It assumes that the JAAL is in the same folder as the jsav-exercise-recorder.
`validation/validator.js`: Validate the data against the JAAL 1.1 schema.

Right now the data produced causes 9 errors:
- Metadata is missing 3 properties: jaalVersion, jaalGenerator, exercise
- Definitions is missing 1 property: styles (is named style in the produced data)
- Definitions/score is missing 4 properties: modelSteps, studentSteps, correctSteps, undoSteps (named differently in produced data)
- Definitions/modelAnswer has the wrong type.