### PR TITLE
Produce valid JAAL 1.1 for the model recording

### DIFF
--- a/animation/animation.js
+++ b/animation/animation.js
@@ -123,7 +123,7 @@ function addStepToSubmission(eventData, dataStructuresState, svgImage) {
     type: type,
     time: (Date.parse(tstamp) - Date.parse(startTime)),
     currentStep: currentStep,
-    // image: svgImage,
+    image: svgImage,
   };
 
   if (type === "click") {
@@ -138,10 +138,12 @@ function addStepToSubmission(eventData, dataStructuresState, svgImage) {
 }
 
 function handleGradeButtonClick(eventData) {
+  const startTime = submission.state().metadata.recordingStarted;
+  const tstamp = eventData.tstamp || new Date();
   try {
     submission.addAnimationStepSuccesfully.gradeButtonClick({
       type: "grade",
-      tstamp: eventData.tstamp,
+      time: (Date.parse(tstamp) - Date.parse(startTime)),
       currentStep: eventData.currentStep,
       score: { ...eventData.score },
 
@@ -157,5 +159,6 @@ module.exports = {
   handleEdgeEvents: edgeAnimation.handleEdgeEvents,
   handleGradableStep,
   handleGradeButtonClick,
-  handleModelAnswer: modelAnswerAnimation.handleModelAnswer
+  handleModelAnswer: modelAnswerAnimation.handleModelAnswer,
+  edgeChanged
 }

--- a/animation/svg.js
+++ b/animation/svg.js
@@ -78,7 +78,7 @@ function addEdges () {
  * @returns svg for the label
  */
 function addEdgeLabel (label) {
-    const pos = label.getAttribute("style");
+    const pos = label.getAttribute("style").replace(" display: block;", "");;
     //Format: "top: ${Y}px; left: ${X}px;"
     const part = pos.split("px; left: "); //["top: ${Y}", "${X}px;"]
     //add offset for top aligned vs bot aligned. 
@@ -171,5 +171,9 @@ function createSvg ()  {
 }
 
 module.exports = {
-    createSvg
+    createSvg,
+    addNode, 
+    addEdge,
+    addEdgeLabel,
+    rgbToHex
 }

--- a/definitions/model-answer/model-answer-definitions.js
+++ b/definitions/model-answer/model-answer-definitions.js
@@ -4,6 +4,12 @@
 // Model answer recording functionality
 
 const submission = require('../../submission/submission');
+const animation = require('../../animation/animation');
+const jaalID = require('../../dataStructures/jaalID');
+const graph = require('../../dataStructures/graph/graph');
+const modelSvg = require('./model-svg');
+// Global var to keep track of the last-known edge state.
+var state = undefined;
 
 // Adds the model answer JavaScript function as a string.
 // JAAL: definitions.modelAnswer.function
@@ -17,23 +23,77 @@ function recordModelAnswerFunction(modelAnswerFunction) {
   return true;
 }
 
-// Records the current step of the model answer.
-// JAAL: definitions.modelAnswer.steps[i]
-// Parameters:
-//     exercise: a JSAV exercise
-// Returns:
-//     true if the model answer step was recorded successfully, false otherwise
+/**
+ * Check whether there is a change in one of the edges that would indicate
+ * an edge having been clicked. 
+ * @param gr the root HTML node of the graph. 
+ * @returns the edge id if an edge has been changed, 
+ *          undefined if no changes
+ */
+function getChangedEdge (gr) {
+  const jaalEdgeList = graph.edges(gr);
+
+  const lastState = (submission.state().definitions.modelAnswer.length === 0)
+                  ? jaalEdgeList : state;
+  
+  state = jaalEdgeList;
+  for (var i = 0; i < jaalEdgeList.length; i++) {
+    if (animation.edgeChanged(jaalEdgeList[i], lastState)) {
+      return jaalEdgeList[i].id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get the table from the canvas HTML and return it as a matrix.
+ * The index fields are used to generate a jsav-id, as the entries do 
+ * not have their on jsav-id.
+ * @returns a matrix of the table
+ */
+function getTable () {
+  const canvasHTML = $('.jsavmodelanswer .jsavcanvas');
+  const table = canvasHTML.children(".jsavmatrixtable");
+  const rows = [...table["0"].children];
+  const matrix = [];
+
+  for (var i = 0; i < rows.length; i++) {
+    const fields = [...rows[i].children];
+    const row = [];
+    for (var j = 0; j < fields.length; j++){
+      // const id = "tablefield_" + i + "_" + j;
+      // const nodeID = jaalID.getJaalID(id, "node")
+      // row.push({id: nodeID, key: fields[j].textContent});
+      row.push(fields[j].textContent);
+    }
+    matrix.push(row);
+  }
+  return matrix;
+}
+
+/**
+ * Records the current step of the model answer.
+ * JAAL: definitions.modelAnswer.steps[i]
+ * @param exercise a JSAV exercise
+ * @returns true if the model answer step was recorded successfully, false otherwise
+ */
 function recordModelAnswerStep(exercise) {
   const redoArray = exercise.modelav._redo;
   if (redoArray.length >= 0) {
-    const dataStructures = dataStructuresNode(exercise);
-    const operations = operationsNode(redoArray);
-    const html = getModelAnswerStepHTML();
+    const e = getChangedEdge(exercise.modelStructures);
+    const table = getTable();
+    const svg = modelSvg.createSvg();
     const modelAnswerStep = {
-      dataStructures,
-      operations,
-      html
+      type: (e) ? "click" : "narration",
+      time: submission.state().definitions.modelAnswer.length,
+      // svg: svg,
+      table: table,
+      explanation: getNarration(),
     };
+    if (e) {
+      modelAnswerStep.object = e;
+      modelAnswerStep.svg = svg;
+    } 
     submission.addDefinitionSuccesfully.modelAnswerStep(modelAnswerStep);
     return (redoArray.length !== 0);
   }
@@ -84,6 +144,10 @@ function getFormattedOperationArgs(args) {
   return formattedArgs;
 }
 
+function getNarration() {
+  return $('.jsavmodelanswer .jsavoutput').children().html();
+}
+
 // JAAL: definitions.modelAnswer.steps[i].html
 function getModelAnswerStepHTML() {
   let counterHTML = $('.jsavmodelanswer .jsavcounter').html();
@@ -94,8 +158,7 @@ function getModelAnswerStepHTML() {
 
 // Returns the number of the current step in the model answer slideshow
 function modelAnswerProgress() {
-  return submission.state().definitions.modelAnswer.steps
-                   .slice(-1)[0].html.counterHTML;
+  return submission.state().definitions.modelAnswer.length;
 }
 
 

--- a/definitions/model-answer/model-svg.js
+++ b/definitions/model-answer/model-svg.js
@@ -1,0 +1,157 @@
+/**
+ * Create an svg of the model solution step. 
+ * The SVG contains the same information as on the model answer animation
+ * Albeit in a slightly different layout
+ */
+
+// Use some of the SVG functions.
+const svg = require('../../animation/svg');
+
+
+/**
+ * Trim the passed along svg canvas to contain minimal necessary information
+ * @param svgElement the HTML element for the svg.
+ * @returns a string of the trimmed svg input. 
+ */
+function svgTrimming(svgElement) {
+  const elementsList = [...svgElement.children]
+
+  var svgOutput = "";
+  for (var i = 0; i < elementsList.length; i++) {
+    const className = elementsList[i].className.baseVal
+    if (className.includes("jsavedge")) {
+      svgOutput += svg.addEdge(elementsList[i]);
+    }
+  }
+  return svgOutput;
+}
+
+/**
+ * Encapsulate the svg data in the svg headers. This also sets the final canvas size.
+ * @param data the svg string to be encapsulated in svg header
+ * @param canvasHTML the canvasHTML element, for grabbing the height and width
+ * of the svg canvas.
+ * @returns the finished svg data.
+ */
+function encapsulateSvg(data, canvasHTML) {
+  const height = canvasHTML.css("min-height");
+  const width = canvasHTML.css("min-width");
+  const fill = svg.rgbToHex(canvasHTML.css("background-color"));
+
+  return "<svg height=\""+ height + "\" version=\"1.1\" width=\"" + width 
+       + "\" xmlns=\"http://www.w3.org/2000/svg\" style=\"overflow: hidden;\">"
+       + "\n<rect fill=\"" + fill + "\" height=\""+ height+ "\" width=\"" 
+       + width + "\" x=\"0\" y=\"0\"/>\n" + data + " </svg>";
+}
+
+/**
+ * Encapsulate the svg of the graph in the right position. 
+ * @param data the string of the graph svg.
+ * @param innerSvg the HTML svg element that contains the information
+ * on the size of the graph
+ * @returns an svg string
+ */
+function encapsulateGraph(data, innerSvg) {
+  const canvasHTML = $('.jsavmodelanswer .jsavcanvas');
+  const width = canvasHTML.css("min-width");
+  const height = canvasHTML.css("min-height");
+  const innerSvgWidth = innerSvg.width.baseVal.value;
+  const innerSvgHeight = innerSvg.height.baseVal.value;
+  const transWidth = (Number(width.slice(0, -2)) - innerSvgWidth)/2;
+  const transHeight = (Number(height.slice(0, -2)) - innerSvgHeight)/2;
+
+  return "<g transform=\"translate(" 
+       + Math.round(transWidth) + "," + Math.round(transHeight) + ")\">\n" 
+       + data + "</g>";
+}
+
+/**
+ * Generate the svg of the graph. 
+ * @param graphChildren a list of HTML elements that make up the graph. 
+ * @returns the svg representation of the graph. 
+ */
+function graphSvg(graphChildren) {
+  var svgOutput = "";
+  var svgIndex = 0;
+  for (var i = 0; i < graphChildren.length; i++){
+    if (graphChildren[i] instanceof SVGElement){
+      //Element is the svg canvas
+      svgOutput += svgTrimming(graphChildren[i]);
+      svgIndex = i;
+    } else if (graphChildren[i].className.includes("jsavgraphnode")) {
+      //Element is a node
+      svgOutput += svg.addNode(graphChildren[i]);
+    } else if (graphChildren[i].className.includes("jsavedgelabel")) {
+      //Element is an edge label
+      svgOutput += svg.addEdgeLabel(graphChildren[i]);
+    } else {
+      console.warn("Missing information about the following node: \n", 
+                    graphChildren[i])
+    }
+  }
+
+  return encapsulateGraph(svgOutput, graphChildren[svgIndex]);
+}
+
+
+/**
+ * Generate the svg representation of the table.
+ * @param {*} tableChildren 
+ * @returns 
+ */
+function tableSvg(tableChildren) {
+  var offsetY = 0;
+  var svgOutput = "";
+
+  for (var i = 0; i < tableChildren.length; i++){
+    const li = [...tableChildren[i].children];
+    var offsetX = 0;
+    const height = Number(getComputedStyle(li[0])
+                            .getPropertyValue("min-height")
+                            .slice(0,-2));
+
+    for (var j = 0; j < li.length; j++) {
+      const text = li[j].textContent;
+      const width = Number(getComputedStyle(li[j])
+                            .getPropertyValue("min-width")
+                            .slice(0,-2));
+      const colour = getComputedStyle(li[j])
+                            .getPropertyValue("background-color");
+      const textX = offsetX + width/2;
+      const textY = offsetY + height/2 + 5;
+      svgOutput += "<rect x=\" " + offsetX + "\" y=\""+ offsetY + "\" width=\""
+                + width + "\" height=\"" + height+ "\" fill=\""
+                + svg.rgbToHex(colour) + "\"></rect>\n" 
+                + "<text x=\"" + textX + "\" y=\"" + textY 
+                + "\" text-anchor=\"middle\">" + text + "</text>\n";
+      offsetX += width;
+    }
+
+    offsetY += height;
+  }
+  return svgOutput;
+}
+
+function narration(table) {
+  const narr = $('.jsavmodelanswer .jsavoutput').children().html();
+
+  const tableOffset = Number(getComputedStyle(table[0]).getPropertyValue("width").replace("px", "")) + 10;
+  return "<text x=\"" + tableOffset + "\" y=\"20\">" + narr + "</text>";
+}
+
+function createSvg() {
+  const canvasHTML = $('.jsavmodelanswer .jsavcanvas');
+  const graphHTML = canvasHTML.children()["0"];
+  const tableHTML = canvasHTML.children()["1"];
+    
+  var svgOutput= graphSvg([...graphHTML.children]);
+  svgOutput += tableSvg([...tableHTML.children]);
+  svgOutput += narration([...tableHTML.children]);
+  svgOutput = encapsulateSvg(svgOutput, canvasHTML);
+  // console.log(svgOutput);
+  return svgOutput;
+}
+
+module.exports = {
+    createSvg,
+}

--- a/exerciseRecorder.js
+++ b/exerciseRecorder.js
@@ -192,51 +192,51 @@ function passEvent(eventData) {
       anim_func.handleGradableStep(exercise, eventData);
       break;
     case 'jsav-exercise-model-open':
-      // // User clicks the Model answer button
-      // modelAnswer.opened = true;
-      // modelAnswer.ready = true;
+      // User clicks the Model answer button
+      modelAnswer.opened = true;
+      modelAnswer.ready = true;
       break;
     case 'jsav-exercise-model-init':
-      // if (!modelAnswer.opened) {
-      //   exercise.modelav.SPEED = modelAnswer.recordingSpeed + 10;
-      //   modelAnswer.ready = !def_func.modelAnswer.recordStep(exercise);
-      //   $('.jsavmodelanswer .jsavforward').click();
-      //   break;
-      // }
+      if (!modelAnswer.opened) {
+        exercise.modelav.SPEED = modelAnswer.recordingSpeed + 10;
+        modelAnswer.ready = !def_func.modelAnswer.recordStep(exercise);
+        $('.jsavmodelanswer .jsavforward').click();
+        break;
+      }
       break;
     case 'jsav-exercise-model-forward':
-      // // The Forward button of the model answer animation was clicked.
-      // if (!modelAnswer.opened && !modelAnswer.ready) {
-      //   // The user had clicked Grade button. Now the model answer recording
-      //   // is in progress.
-      //   setTimeout(() => {
-      //     // Record current step of model answer
-      //     modelAnswer.ready = !def_func.modelAnswer.recordStep(exercise);
-      //     // Trigger this click event again
-      //     $('.jsavmodelanswer .jsavforward').click();
-      //   }, modelAnswer.recordingSpeed);
-      // }
-      // else {
-      //   // The user clicked Forward button in the model answer
-      // }
+      // The Forward button of the model answer animation was clicked.
+      if (!modelAnswer.opened && !modelAnswer.ready) {
+        // The user had clicked Grade button. Now the model answer recording
+        // is in progress.
+        setTimeout(() => {
+          // Record current step of model answer
+          modelAnswer.ready = !def_func.modelAnswer.recordStep(exercise);
+          // Trigger this click event again
+          $('.jsavmodelanswer .jsavforward').click();
+        }, modelAnswer.recordingSpeed);
+      }
+      else {
+        // The user clicked Forward button in the model answer
+      }
       break;
     case String(eventData.type.match(/^jsav-exercise-model-.*/)):
-      // // All user actions with the model answer animation
-      // if (modelAnswer.opened) {
-      //   anim_func.handleModelAnswer(exercise, eventData);
-      // }
+      // All user actions with the model answer animation
+      if (modelAnswer.opened) {
+        anim_func.handleModelAnswer(exercise, eventData);
+      }
       break;
     case 'jsav-exercise-grade-button':
       // User clicks the Grade button
       break;
     case 'jsav-exercise-grade':
       // Automatic grading of the exercise has finished
-      // if(!modelAnswer.opened) {
-      //   const popUpText = `Recording model answer steps\n ${def_func.modelAnswer.progress()}`;
-      //   const popUp = helpers.getPopUp(popUpText);
-      //   $('body').append(popUp);
-      // }
-      // finish(eventData);
+      if(!modelAnswer.opened) {
+        const popUpText = `Recording model answer steps\n ${def_func.modelAnswer.progress()}`;
+        const popUp = helpers.getPopUp(popUpText);
+        $('body').append(popUp);
+      }
+      finish(eventData);
       finishWithoutModelAnswer(eventData);
       break;
     case 'jsav-exercise-reset':
@@ -255,6 +255,7 @@ function finish(eventData) {
   if (modelAnswer.ready) {
     anim_func.handleGradeButtonClick(eventData);
     def_func.setFinalGrade(eventData);
+    validator_func.validateData(submission.state());
     JSAVrecorder.sendSubmission(submission.state())
 
     submission.reset();

--- a/submission/submission.js
+++ b/submission/submission.js
@@ -147,11 +147,11 @@ function addModelAnswerFunction(modelAnswerFunction) {
 }
 
 function addModelAnswerStep(step) {
-  if(valid.modelAnswerStep(step)) {
-    submission.definitions.modelAnswer.steps.push(step);
+  // if(valid.modelAnswerStep(step)) {
+    submission.definitions.modelAnswer.push(step);
     return true;
-  }
-  return false;
+  // }
+  // return false;
 }
 
 


### PR DESCRIPTION
Fulfil #31 and #32 . 

`submission.js`: Surpress modelAnswerStep validation.
`model-svg.js`: Create an svg of the model solution.
`model-answer-definition.js`: Record JAAL 1.1 for the model solution,
save current state as svg rather than three HTML dumps.
modelAnswerStep now lists the type as `click` or `narration`.
The `time` field is the current step count. The `explanation` field contains
the string of explanation given about the current step in the modelSolution.
A table is generated for every step, and an svg for every click event.
`svg.js`: add `.replace(" display: block;")` to the addEdgeLabel to allow
the same function to be used for the modelSvg. Export some functions to allow
usage in modelSvg building.
`animation.js`: make the grade event valid JAAL 1.1. Export edge changed
function for use in model-svg.
`exerciseRecorder.js`: Uncomment the lines needed for model solution
generation. Add the call to JAAL 1.1 validation in the finish() function.