### PR TITLE
Exercise player related fixes

### DIFF
--- a/animation/svg.js
+++ b/animation/svg.js
@@ -154,19 +154,6 @@ function createSvg ()  {
     text += addEdgeLabels();
     text += addNodes();
     text = encapsulateSvg(text);
-
-    //For adding the svg image to the end of the page. 
-    const container = document.getElementById("svg_data");
-    if (container === null) {
-        const svg_node = document.createElement("svg");
-        svg_node.id = "svg_data";
-        svg_node.innerHTML = text;
-        document.body.append(svg_node);
-    } else {
-        container.innerHTML = text;
-    }
-
-    // console.log(text);
     return text;
 }
 

--- a/definitions/model-answer/model-answer-definitions.js
+++ b/definitions/model-answer/model-answer-definitions.js
@@ -94,6 +94,9 @@ function recordModelAnswerStep(exercise) {
       modelAnswerStep.object = e;
       modelAnswerStep.svg = svg;
     } 
+    if (modelAnswerStep.time === 1){
+      modelAnswerStep.svg = svg;
+    }
     submission.addDefinitionSuccesfully.modelAnswerStep(modelAnswerStep);
     return (redoArray.length !== 0);
   }

--- a/definitions/model-answer/model-svg.js
+++ b/definitions/model-answer/model-svg.js
@@ -27,21 +27,26 @@ function svgTrimming(svgElement) {
 }
 
 /**
- * Encapsulate the svg data in the svg headers. This also sets the final canvas size.
+ * Encapsulate the svg data in the svg headers. This also sets the final 
+ * canvas size. The width is determined from the combined width of each 
+ * component + 20 pixels per component.
  * @param data the svg string to be encapsulated in svg header
- * @param canvasHTML the canvasHTML element, for grabbing the height and width
+ * @param canvasHTML the canvasHTML element, for grabbing the height 
  * of the svg canvas.
  * @returns the finished svg data.
  */
 function encapsulateSvg(data, canvasHTML) {
+  var width = 0;
+  canvasHTML.children().each(function() {
+    width += Number($(this).css("width").replace("px", "")) + 20
+  })
   const height = canvasHTML.css("min-height");
-  const width = canvasHTML.css("min-width");
   const fill = svg.rgbToHex(canvasHTML.css("background-color"));
 
   return "<svg height=\""+ height + "\" version=\"1.1\" width=\"" + width 
-       + "\" xmlns=\"http://www.w3.org/2000/svg\" style=\"overflow: hidden;\">"
+       + "px\" xmlns=\"http://www.w3.org/2000/svg\" style=\"display: inline;\">"
        + "\n<rect fill=\"" + fill + "\" height=\""+ height+ "\" width=\"" 
-       + width + "\" x=\"0\" y=\"0\"/>\n" + data + " </svg>";
+       + width + "px\" x=\"0\" y=\"0\"/>\n" + data + " </svg>";
 }
 
 /**
@@ -53,11 +58,14 @@ function encapsulateSvg(data, canvasHTML) {
  */
 function encapsulateGraph(data, innerSvg) {
   const canvasHTML = $('.jsavmodelanswer .jsavcanvas');
-  const width = canvasHTML.css("min-width");
+  var width = 0;
+  canvasHTML.children().each(function() {
+    width += Number($(this).css("width").replace("px", "")) + 20
+  })
   const height = canvasHTML.css("min-height");
   const innerSvgWidth = innerSvg.width.baseVal.value;
   const innerSvgHeight = innerSvg.height.baseVal.value;
-  const transWidth = (Number(width.slice(0, -2)) - innerSvgWidth)/2;
+  const transWidth = (width - innerSvgWidth);
   const transHeight = (Number(height.slice(0, -2)) - innerSvgHeight)/2;
 
   return "<g transform=\"translate(" 
@@ -148,7 +156,6 @@ function createSvg() {
   svgOutput += tableSvg([...tableHTML.children]);
   svgOutput += narration([...tableHTML.children]);
   svgOutput = encapsulateSvg(svgOutput, canvasHTML);
-  // console.log(svgOutput);
   return svgOutput;
 }
 

--- a/exerciseRecorder.js
+++ b/exerciseRecorder.js
@@ -140,7 +140,7 @@ function getMetadataFromURLparams() {
 // eventData: { type: string,
 //              exercise: JSAV exercise, ...}
 function passEvent(eventData) {
-  console.log('EVENT DATA', eventData);
+  // console.log('EVENT DATA', eventData);
   switch(eventData.type){
     case 'jsav-init':
       // Set exercise title and instructions
@@ -237,7 +237,7 @@ function passEvent(eventData) {
         $('body').append(popUp);
       }
       finish(eventData);
-      finishWithoutModelAnswer(eventData);
+      // finishWithoutModelAnswer(eventData);
       break;
     case 'jsav-exercise-reset':
       // User clicks the Reset button

--- a/initialState/initialState.js
+++ b/initialState/initialState.js
@@ -2,12 +2,14 @@ const recorder = require('../exerciseRecorder');
 const submission = require('../submission/submission');
 const helpers = require('../utils/helperFunctions');
 const dataStructures = require('../dataStructures/dataStructures');
+const svg = require('../animation/svg')
 
 function setInitialDataStructures(exercise, passEvent) {
   const initialStructures = exercise.initialStructures;
   dataStructures.getDataStructuresFromExercise(exercise,passEvent).forEach(ds => {
     submission.addInitialStateSuccesfully.dataStructure(ds);
   });
+  submission.addInitialStateSuccesfully.addInitialStateSvg(svg.createSvg());
 }
 
 function moreThanOneDs(initialStructures) {

--- a/metadata/metadata.js
+++ b/metadata/metadata.js
@@ -9,7 +9,7 @@ function setExerciseMetadata(metadata) {
   const d = new Date();
   metadata.recordingStarted = d.toISOString();
   metadata.recordingTimezone = -1 * d.getTimezoneOffset() / 60; // hours to UTC
-  metadata.jaalVersion = "1.1";
+  metadata.jaalVersion = version;
   metadata.jaalGenerator = "JSAV Exercise Recorder " + version;
   const windowLocation = window.location.href.split('?')[0];
   const linkParts = windowLocation.split("/");

--- a/submission/submission.js
+++ b/submission/submission.js
@@ -28,6 +28,7 @@ const submission =  {
   },
   initialState: {
     dataStructures: [],
+    svg: "",
     // JAAL 1.0 HTML
     // animationHTML: ""
   },
@@ -55,6 +56,7 @@ function reset() {
   };
   submission.initialState = {
     dataStructures: [],
+    svg: "",
     // JAAL 1.0 HTML
     // animationHTML: ""
   };
@@ -68,6 +70,7 @@ function state() {
   // TODO: change to support new DSs
   const initialState = {
     dataStructures: submission.initialState.dataStructures.map(ds => helpers.copyObject(ds)),
+    svg: submission.initialState.svg
     // JAAL 1.0 HTML
     // animationHTML: submission.initialState.animationHTML
   }
@@ -163,6 +166,10 @@ function addDataStructure(ds) {
   return false;
 }
 
+function addInitialStateSvg(svg) {
+  submission.initialState.svg = svg;
+}
+
 // JAAL 1.0 HTML
 // function addAnimationHTML(html) {
 //   if(valid.animationHTML(html)) {
@@ -252,6 +259,7 @@ const addDefinitionSuccesfully = {
 const addInitialStateSuccesfully = {
   dataStructure: addDataStructure,
   setDsId,
+  addInitialStateSvg,
   // JAAL 1.0 HTML
   // animationHTML: addAnimationHTML,
 };


### PR DESCRIPTION
Exercise recorder updates for PR https://github.com/Aalto-LeTech/jsav-exercise-player/pull/5

`metadata.js`: Correctly set the jaalVersion.
`submission.js`: add svg for the initialState.
`initialState.js`: add svg for the initialState
`model-svg.js`: limit the width of the svg by tallying the width of all of the elements
+ a 20 px margin per element.
`model-answer-definition.js`: add svg to the first step recorded (narration step).
`exerciseRecorder.js`: disable `finishWithoutModelAnswer` as it was causing
double click-handler bugs in the player.
`svg.js`: remove adding svg to end of page, was used for dev.