### PR TITLE
Record Binary Tree as correct JAAL 2.0 for initial state

### DIFF
--- a/dataStructures/tree/binaryTree.js
+++ b/dataStructures/tree/binaryTree.js
@@ -1,19 +1,52 @@
+const jaalID = require("../jaalID");
+
 function getBinaryTree(tree) {
-  const jsavRoot = tree.rootnode;
-  const rootNode = {
-    id: jsavRoot.element[0].id,
-    value: jsavRoot.element[0].dataset.value,
-    childRole: jsavRoot.element[0].dataset.childRole,
-    valueType: jsavRoot.element[0].dataset.valueType,
-    childNodes: getChildNodes(jsavRoot)
-  }
   return {
-    rootNode,
-    id: tree.element[0].id,
-    root: tree.element[0].dataset.root,
-    values: tree.element[0].innerText,
-    type: 'binarytree'
+    id: jaalID.getJaalID(tree.element[0].id, "graph"),
+    root: jaalID.getJaalID(tree.rootnode.element[0].id, "node"),
+    dsClass: "tree",
+    dsSubClass: "binarytree", 
+    directed: true,
+    node: getNodes($(tree.element[0])),
+    edge: getEdges($(tree.element[0])),
   }
+}
+
+function getNodes(tree) {
+  const nodes = tree.find(".jsavbinarynode").not(function() {
+    return $(this).css("display") === "none" || 
+           $(this).hasClass("jsavnullnode")
+  });
+  const nodeArr = [];
+  nodes.each(function() {
+    const node = {
+      id: jaalID.getJaalID($(this).attr("id") , "node"),
+      key: $(this).text(),
+    }
+    nodeArr.push(node);
+  })
+  return nodeArr;
+}
+
+function getEdges(tree) {
+  const edges = tree.find(".jsavedge").not(function() {
+    return $(this).hasClass("jsavnulledge") || 
+           $(this).css("opacity") === "0";
+  });
+  const edgeArr = [];
+  edges.each(function() {
+    const startNodeID = jaalID.getJaalID($(this).attr("data-startnode"), "node");
+    const endNodeID = jaalID.getJaalID($(this).attr("data-endnode"), "node");
+    const startNode = $("#" + $(this).attr("data-startnode"));
+    const edge = {
+      id: jaalID.getJaalID(startNodeID + endNodeID, "edge"),
+      //Startnode is the child node, we want that to be the second one listed
+      node: [endNodeID, startNodeID],
+      relation: startNode.attr("data-binchildrole"),
+    }
+    edgeArr.push(edge);
+  })
+  return edgeArr;
 }
 
 function getChildNodes(node) {


### PR DESCRIPTION
Resolve #63 
`binaryTree.js` now is updated for JAAL 2.0, so the initial tree state
is correctly recorded.

To easily test that the edge functionality is also correct, add the
following to the end of `addMinheap()` in Dijkstra-v2.js:

```
minheap.root("P");
minheap.root().left("Q");
minheap.layout();
```

Then grading the Dijkstra's exercise no longer produces any JAAL
validation errors.