### PR TITLE
Resolve Undo bug and make sure that we're actually grading on the classes

### DIFF
--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
@@ -40,7 +40,7 @@
 
   // JSAV Exercise
   var exercise = jsav.exercise(model, init, {
-    compare: { class: "marked" },
+    compare: [{ class: ["marked", "queued"] }],
     controls: $('.jsavexercisecontrols'),
     fix: fixState
   });
@@ -738,9 +738,9 @@
     const popup = JSAV.utils.dialog(html, options);
 
     // Enqueue and update button event handlers
-    $("#enqueueButton").click({srcLabel, dstLabel, newDist, popup, edge: that},
+    $("#enqueueButton").click({srcLabel, dstLabel, newDist, popup, edge},
                               enqueueClicked);
-    $("#updateButton").click({srcLabel, dstLabel, newDist, popup, edge: that},
+    $("#updateButton").click({srcLabel, dstLabel, newDist, popup, edge},
                               updateClicked);
   }
 


### PR DESCRIPTION


The undo bug appeared because when we added the class 'queued' this was done on the object outside of JSAV. Instead we should add it to the JSAV object, so that JSAV is aware of the change, and thus can keep track of it also for the undo operation.

When grading on multiple data structures, you need to pass along an array to compared with the objects in the order they should be used. So [{graph compare reqs}, {bintree compare reqs}] in the case of Dijkstra v2.