### PR TITLE
Resolve issue #98

### DIFF
--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
@@ -1615,8 +1615,8 @@
       const nodeLabel = deleted.charAt(deleted.length - 5);
       const node = graph.nodes().filter(node =>
           node.element[0].getAttribute("data-value") === nodeLabel)[0];
-      const srcLabel = table.value(2, findColByNode(nodeLabel));
-      // const srcLabel = deleted.charAt(deleted.length - 2);
+      // const srcLabel = table.value(2, findColByNode(nodeLabel));
+      const srcLabel = deleted.charAt(deleted.length - 2);
       const srcNode = graph.nodes().filter(node =>
           node.element[0].getAttribute("data-value") === srcLabel)[0];
       const edge = graph.getEdge(node, srcNode) ?? graph.getEdge(srcNode, node);


### PR DESCRIPTION
Resolve the issue where if a node was in the prio queue several times, it can be that the wrong edge gets added compared to the node removed from the binary tree. the delete button now reads the value from the root of the binary tree, rather than from the table.