### PR TITLE
Fix issue 100 : Model answer width on small screens

### DIFF
--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
@@ -42,7 +42,7 @@
   var exercise = jsav.exercise(model, init, {
     compare: [{ class: ["marked", "queued"] }],
     controls: $('.jsavexercisecontrols'),
-    modelDialog: {width: "920px"},
+    modelDialog: {width: "960px"},
     fix: fixState
   });
   exercise.reset();

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
@@ -42,6 +42,7 @@
   var exercise = jsav.exercise(model, init, {
     compare: [{ class: ["marked", "queued"] }],
     controls: $('.jsavexercisecontrols'),
+    modelDialog: {width: "920px"},
     fix: fixState
   });
   exercise.reset();


### PR DESCRIPTION
The model answer for the Dijkstra is now passed along a fixed width parameter. It now no longer overlaps the table and the graph.