### PR TITLE
Fix the size of the model answers for scaffolded Prim & Dijkstra

### DIFF
--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research-v2.js
@@ -772,6 +772,7 @@
     $(".jsavbinarytree").css("margin-top", "34px");
     $(".jsavmatrix").css("margin-top", "34px");
     $(".jsavcanvas").css("min-height", "910px");
+    $(".jsavmodelanswer .jsavcanvas").css("min-height", "770px");
   })
 
   $("#about").click(about);

--- a/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.js
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.js
@@ -573,6 +573,7 @@
   exercise = jsav.exercise(model, init, {
     compare: [{ class: "marked" }],
     controls: $('.jsavexercisecontrols'),
+    modelDialog: {width: "960px"},
     fix: fixState
   });
   exercise.reset();
@@ -600,6 +601,7 @@
     $(".jsavbinarytree").css("margin-top", "34px");
     $(".jsavmatrix").css("margin-top", "34px");
     $(".jsavcanvas").css("min-height", "910px");
+    $(".jsavmodelanswer .jsavcanvas").css("min-height", "700px");
   })
 
   $("#about").click(about);


### PR DESCRIPTION
Resolve one of the TODOs from PR #101 : 
> model answer text av_ms_visit_neighbor_update: second row is wrapped, thus the end of it is not visible.

Dijkstra: make the model answer canvas height smaller so that we don't have an unnecessarily tall model answer box. 

Prim: force the width of the model answer canvas to be 960px so that the text doesn't disappear behind the canvas. Make the model answer canvas height smaller so that we don't have an unnecessarily tall model answer box.