### PR TITLE
Resolve issues #107 and #104

### DIFF
--- a/dataStructures/jaalID.js
+++ b/dataStructures/jaalID.js
@@ -41,6 +41,16 @@ function getJaalID (jsavID, type) {
     return jaalID;
 }
 
+function resetJaalIDs () {
+    ids.edge = 1;
+    ids.graph = 1;
+    ids.keyvalue = 1;
+    ids.matrix = 1;
+    ids.node = 1;
+    jsavToJaalID.clear();
+}
+
 module.exports = {
-    getJaalID
+    getJaalID,
+    resetJaalIDs,
 }

--- a/exerciseRecorder.js
+++ b/exerciseRecorder.js
@@ -12,6 +12,7 @@ const def_func = require('./definitions/definitions');
 const init_state_func = require('./initialState/initialState');
 const anim_func = require('./animation/animation');
 const validator_func = require('./validation/validator');
+const jaalIDs = require('./dataStructures/jaalID');
 
 // Services module is not needed, because OpenDSA code will handle the
 // communication to A+ LMS through mooc-grader.
@@ -265,6 +266,9 @@ function passEvent(eventData) {
       break;
     case 'jsav-exercise-reset':
       // User clicks the Reset button
+      modelAnswer.opened = false;
+      modelAnswer.ready = false;
+      jaalIDs.resetJaalIDs();
       console.warn('Resetting submission');
       submission.reset();
       break;


### PR DESCRIPTION
After the model answer was opened, the JAAL data would no longer contain the model answer for that session. This was due to the modelAnswer.opened flag being set to true the first time the model answer was opened, and never set to false. Only with this flag on false will the recorder record the model answer. Now on reset, modelAnswer.opened and modelAnswer.ready are set to false, so that the model answer will be recorded even if the model solution has been looked at by the student for an earlier exercise that session.

Additionally also reset the JAAL ids when the reset button is pressed. The JAAL id counters are reset to 1, and the jsav to jaal id mapping is cleared when reset is pressed.