### PR TITLE
Resolve #110 for Scaffolded Prim

### DIFF
--- a/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.js
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.js
@@ -205,7 +205,8 @@
       }
       const neighbours = dstNode.neighbors().filter(node =>
         !node.hasClass("marked"));
-      neighbours.sort((a, b) => a.value() > b.value());
+      debugPrint("Neighbours of " + dstNode.value() + " before sorting");
+      sortNeighbours(neighbours);
       neighbours.forEach(node => visitNeighbour(dstNode, node))
     }
     av.umsg(interpret("av_ms_unreachable"));
@@ -218,6 +219,8 @@
      * @param neighbour neighbour node that is visited
      */
     function visitNeighbour (src, neighbour) {
+      debugPrint("visitNeighbour: src = " + src.value() + ", neighbour = " +
+      neighbour.value());
       const edge = src.edgeTo(neighbour) ?? src.edgeFrom(neighbour);
       const neighbourIndex = neighbour.value().charCodeAt(0) - "A".charCodeAt(0);
       const currNeighbourDist = getDistance(neighbourIndex);
@@ -386,6 +389,30 @@
         node = node.parent();
       }
       mintree.layout();
+    }
+
+    /* Sorts neighbours of a node by alphabetic order of their node values.
+    * Implementation: selection sort.
+    * This function was implemented because the default
+    * Array.prototype.sort() was not functioning correctly with an array of
+    * JSAV Nodes under Google Chrome. */
+    function sortNeighbours(neighbours) {
+      for (let i = 0; i < neighbours.length - 1; i++) {
+        let minIndex = i;
+        let minVal = neighbours[i].value();
+        for (let j = i + 1; j < neighbours.length; j++) {
+          let newVal = neighbours[j].value();
+          if (newVal < minVal) {
+            minVal = newVal;
+            minIndex = j;
+          }
+        }
+        if (minIndex !== i) {
+          let tmp = neighbours[i];
+          neighbours[i] = neighbours[minIndex];
+          neighbours[minIndex] = tmp;
+        }
+      }
     }
 
     function highlight(edge, node) {
@@ -1052,7 +1079,7 @@
 
   function debugPrint(x) {
     if (debug) {
-      debugPrint(x);
+      console.log(x);
     }
   }
 


### PR DESCRIPTION
The fix that was implemented for scaffolded Dijkstra is now applied to scaffolded Prim. The fix should not be necessary for non-scaffolded Dijkstra or Prim, since they do not make use of the priority queue, and rather use the list implementation in the model answer.

I have tested with Chrome and Firefox under Ubuntu 20 and get alphabetical processing for scaffolded Prim.