### PR TITLE
BFS/DFS: Resolve trivial graphs and Model Answer being partially cut off

### DIFF
--- a/testbench/OpenDSA/AV/Development/graphBFSPE.css
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.css
@@ -1,0 +1,27 @@
+#container {
+  width: 800px;
+  height: 595px;
+}
+.jsavline {
+  height: 45px;
+  margin: 0 0 0 20px;
+}
+
+#procontrols {
+  text-align: center;
+}
+
+.jsavgraph svg {
+  z-index: 0;
+}
+
+.jsavnode.marked {
+  background-color: #FFF050;
+}
+.jsavedge {
+  stroke-width: 8;
+  stroke: #7D8879;
+}
+.jsavedge.marked {
+  stroke: #F6B611;
+}

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.css
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.css
@@ -16,12 +16,12 @@
 }
 
 .jsavnode.marked {
-  background-color: #FFF050;
+  background-color: #ffe100;
 }
 .jsavedge {
   stroke-width: 8;
-  stroke: #7D8879;
+  stroke: #d1c39d;
 }
 .jsavedge.marked {
-  stroke: #F6B611;
+  stroke: #ffe100;
 }

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.html
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Breadth First Search Algorithm Proficiency Exercise</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="../../JSAV/css/JSAV.css" type="text/css" />
+    <link rel="stylesheet" href="../../lib/odsaAV-min.css" type="text/css" />
+    <link rel="stylesheet" href="graphBFSPE.css" />
+  </head>
+  <body>
+    <div id="container">
+      <table class="proHeaderTable">
+        <tr>
+          <td class="headerLeft">
+            <input type="button" id="help" name="help" value="Help" />
+          </td>
+          <td class="headerCenter">
+            <p class="jsavexercisecontrols"></p>
+          </td>
+          <td class="headerRight">
+            <input type="button" id="about" name="about" value="About" />
+            <a id="settings" class="jsavsettings" href="#">Settings</a>
+          </td>
+        </tr>
+      </table>
+      <form class="avcontainer">
+        <div class="jsavcanvas">
+          <p class="instructLabel"></p>
+          <p class="instructions"></p>
+          <p id="procontrols">
+            <span class="jsavscore"></span>
+          </p>
+        </div>
+      </form>
+    </div>
+    <script src="../../lib/jquery.min.js"></script>
+    <script src="../../lib/jquery-ui.min.js"></script>
+    <script src="../../JSAV/lib/jquery.transit.js"></script>
+    <script src="../../JSAV/lib/raphael.js"></script>
+    <script src="../../JSAV/build/JSAV-min.js"></script>
+    <script src="../../DataStructures/binaryheap.js"></script>
+    <script src="../../lib/odsaUtils-min.js"></script>
+    <script src="../../lib/odsaAV-min.js"></script>
+    <script src="graphUtils.js"></script>
+    <script src="graphBFSPE.js"></script>
+  </body>
+</html>

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.js
@@ -114,7 +114,7 @@
     var i;
     // create the model
     var modelGraph = modeljsav.ds.graph({
-      width: 400,
+      width: 500,
       height: 400,
       layout: "automatic",
       directed: false

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.js
@@ -213,6 +213,7 @@
   exercise = jsav.exercise(model, init, {
     compare: {class: "marked"},
     controls: $(".jsavexercisecontrols"),
+    resetButtonTitle: interpret("reset"),
     fix: fixState
   });
   exercise.reset();

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.js
@@ -42,6 +42,13 @@
     let nlGraph = graphUtils.generatePlanarNl(nVertices, nEdges, weighted,
         directed, width, height);
 
+    // Assure that the random planar graph has A connected to another node
+    // and a sufficiently large spanning tree, i.e. at least 7 edges
+    while (spanning_tree(nlGraph).length < 7) {
+      console.warn("TOO SMALL SPANNING TREE:", spanning_tree(nlGraph).length);
+      nlGraph = graphUtils.generatePlanarNl(nVertices, nEdges, weighted, directed, width, height);
+    }
+
     // Create a JSAV graph instance
     if (graph) {
       graph.clear();
@@ -57,6 +64,34 @@
     graph.nodes()[0].addClass("marked"); // mark the 'A' node
     jsav.displayInit();
     return graph;
+  }
+
+  /**
+   * Calculate the spanning tree for the nlGraph. This is used to ensure
+   * that the spanning tree is sufficiently large and the exercise is not
+   * trivially easy. 
+   * The spanning tree is calculated using the BFS algorithm. 
+   * @param nlGraph as returned by graphUtils.js
+   * @returns spanning tree edge list
+   */
+  function spanning_tree(nlGraph) {
+    let visited = [];
+    let queue = [];
+    let edges = []; //Edges selected in the bfs spanning tree.
+    let node = 0;
+    queue.push(node);
+
+    while (queue.length > 0) {
+      node = queue.shift();
+      visited.push(node);
+      for (const neighbor of nlGraph.edges[node]) {
+        if (!visited.includes(neighbor.v) && !queue.includes(neighbor.v)) {
+          queue.push(neighbor.v);
+          edges.push([node, neighbor.v]);
+        }
+      }
+    }
+    return edges;
   }
 
   function fixState(modelGraph) {

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.js
@@ -1,0 +1,197 @@
+/* global graphUtils */
+(function() {
+  "use strict";
+  var exercise,
+      graph,
+      config = ODSA.UTILS.loadConfig(),
+      interpret = config.interpreter,
+      settings = config.getSettings(),
+      jsav = new JSAV($(".avcontainer"), {settings: settings});
+
+  jsav.recorded();
+
+  function init_old() {
+    // create the graph
+    if (graph) {
+      graph.clear();
+    }
+    graph = jsav.ds.graph({
+      width: 400,
+      height: 400,
+      layout: "automatic",
+      directed: false
+    });
+    graphUtils.generate(graph); // Randomly generate the graph without weights
+    graph.layout();
+    // mark the "A" node
+    graph.nodes()[0].addClass("marked");
+
+    jsav.displayInit();
+    return graph;
+  }
+
+  function init() {
+    // Settings for input
+    const width = 500, height = 400,  // pixels
+          weighted = false,
+          directed = false,
+          nVertices = [11, 3],
+          nEdges = [14, 2];
+
+    // First create a random planar graph instance in neighbour list format
+    let nlGraph = graphUtils.generatePlanarNl(nVertices, nEdges, weighted,
+        directed, width, height);
+
+    // Create a JSAV graph instance
+    if (graph) {
+      graph.clear();
+    }
+    graph = jsav.ds.graph({//    Condition:
+      width: width,
+      height: height,
+      layout: "manual",
+      directed: directed
+    });
+    graphUtils.nlToJsav(nlGraph, graph);
+    graph.layout();
+    graph.nodes()[0].addClass("marked"); // mark the 'A' node
+    jsav.displayInit();
+    return graph;
+  }
+
+  function fixState(modelGraph) {
+    var graphEdges = graph.edges(),
+        modelEdges = modelGraph.edges();
+
+    // compare the edges between exercise and model
+    for (var i = 0; i < graphEdges.length; i++) {
+      var edge = graphEdges[i],
+          modelEdge = modelEdges[i];
+      if (modelEdge.hasClass("marked") && !edge.hasClass("marked")) {
+        // mark the edge that is marked in the model, but not in the exercise
+        markEdge(edge);
+        break;
+      }
+    }
+  }
+
+  function model(modeljsav) {
+    var i;
+    // create the model
+    var modelGraph = modeljsav.ds.graph({
+      width: 400,
+      height: 400,
+      layout: "automatic",
+      directed: false
+    });
+
+    // copy the graph and its weights
+    graphUtils.copy(graph, modelGraph, {weights: true});
+    var modelNodes = modelGraph.nodes();
+
+    // Mark the "A" node
+    modelNodes[0].addClass("marked");
+
+    modeljsav.displayInit();
+
+    // start the algorithm
+    bfs(modelNodes[0], modeljsav);
+
+    modeljsav.umsg(interpret("av_ms_final"));
+    // hide all edges that are not part of the search tree
+    var modelEdges = modelGraph.edges();
+    for (i = 0; i < modelGraph.edges().length; i++) {
+      if (!modelEdges[i].hasClass("marked")) {
+        modelEdges[i].hide();
+      }
+    }
+
+    modeljsav.step();
+
+    return modelGraph;
+  }
+
+  function markEdge(edge, av) {
+    edge.addClass("marked");
+    edge.start().addClass("marked");
+    edge.end().addClass("marked");
+    if (av) {
+      av.gradeableStep();
+    } else {
+      exercise.gradeableStep();
+    }
+  }
+
+  function bfs(start, av) {
+    var queue = [start],
+        node,
+        neighbor,
+        adjacent;
+    function nodeSort(a, b) {
+      return a.value().charCodeAt(0) - b.value().charCodeAt(0);
+    }
+
+    while (queue.length) {
+      // dequeue node
+      node = queue.pop();
+      // get neighbors and sort them in alphabetical order
+      adjacent = node.neighbors();
+      adjacent.sort(nodeSort);
+      av.umsg(interpret("av_ms_dequeue"), {fill: {node: node.value()}});
+      av.step();
+
+      // Check if all neighbors have already been visited
+      var visitedAll = adjacent.every(function(n) { return n.hasClass("marked"); });
+
+      if (!visitedAll) {
+        // go through all neighbors
+        while (adjacent.hasNext()) {
+          neighbor = adjacent.next();
+          av.umsg(interpret("av_ms_process_edge"), {fill: {from: node.value(), to: neighbor.value()}});
+          if (!neighbor.hasClass("marked")) {
+            // enqueue and visit node
+            queue.unshift(neighbor);
+            markEdge(node.edgeTo(neighbor), av);
+          } else {
+            av.umsg(interpret("av_ms_already_visited"), {
+              preserve: true,
+              fill: {
+                node: neighbor.value()
+              }
+            });
+            av.step();
+          }
+        }
+      } else {
+        av.umsg(interpret("av_ms_all_neighbors_visited"), {fill: {node: node.value()}});
+        av.step();
+      }
+    }
+  }
+
+
+  // Process About button: Pop up a message with an Alert
+  function about() {
+    window.alert(ODSA.AV.aboutstring(interpret(".avTitle"), interpret("av_Authors")));
+  }
+
+  exercise = jsav.exercise(model, init, {
+    compare: {class: "marked"},
+    controls: $(".jsavexercisecontrols"),
+    fix: fixState
+  });
+  exercise.reset();
+
+  $(".jsavcontainer").on("click", ".jsavedge", function() {
+    var edge = $(this).data("edge");
+    if (!edge.hasClass("marked")) {
+      markEdge(edge);
+    }
+  });
+
+  $(".jsavcontainer").on("click", ".jsavnode", function() {
+    window.alert("Please, click on the edges, not the nodes.");
+  });
+
+  $("#about").click(about);
+})();

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.json
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.json
@@ -1,0 +1,34 @@
+{
+  "translations" :{
+    "en": {
+      ".avTitle": "Breadth-First Search Proficiency Exercise",
+      "av_Authors": "Mohammed Fawzi, Kasper Hellström",
+      ".instructLabel": "Instructions:",
+      ".instructions": "Reproduce the behavior of the BFS algorithm for the graph below. Just click on the <strong>edges</strong> in the order that they will be traversed by the BFS algorithm. Start with Node A. If there is more than one node that could be visited next, choose the one that comes first in alphabetical order.",
+      "av_ms_final": "Final BFS graph",
+      "av_ms_dequeue": "Dequeue {node}",
+      "av_ms_process_edge": "Process edge ({from}, {to}).",
+      "av_ms_already_visited": " Node {node} already visited",
+      "av_ms_all_neighbors_visited": "All the neighbors of {node} have already been visited.\n",
+      "#help": "Help",
+      "#about": "About"
+    },
+    "fi": {
+      ".avTitle": "Syvyyssuuntainen haku",
+      "av_Authors": "Mohammed Fawzi, Kasper Hellström",
+      ".instructLabel": "Ohjeet:",
+      ".instructions": "Käy läpi verkko BFS-järjestyksessä. Aloita läpikäynti solmusta A. Klikkaa <strong>särmiä</strong> samassa järjestyksessä kuin BFS-algoritmi käy ne läpi. Solmun naapurit käydään läpi aakkosjärjestyksessä.",
+      "av_ms_final": "BFS-algoritmin virityspuu",
+      "av_ms_dequeue": "Poistetaan {node} jonosta",
+      "av_ms_process_edge": "Prosessoidaan särmää ({from}, {to}).",
+      "av_ms_already_visited": " Solmu {node} on jo läpikäyty",
+      "av_ms_all_neighbors_visited": "Kaikki {node}:n naapurit on läpikäyty.\n",
+      "#help": "Ohje",
+      "#about": "Lisätietoa"
+    }
+  },
+  "params": {
+    "JXOP-feedback": "continuous",
+    "JXOP-fixmode": "fix"
+  }
+}

--- a/testbench/OpenDSA/AV/Development/graphBFSPE.json
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.json
@@ -11,7 +11,8 @@
       "av_ms_already_visited": " Node {node} already visited",
       "av_ms_all_neighbors_visited": "All the neighbors of {node} have already been visited.\n",
       "#help": "Help",
-      "#about": "About"
+      "#about": "About", 
+      "reset": "New Exercise"
     },
     "fi": {
       ".avTitle": "Syvyyssuuntainen haku",
@@ -24,7 +25,8 @@
       "av_ms_already_visited": " Solmu {node} on jo läpikäyty",
       "av_ms_all_neighbors_visited": "Kaikki {node}:n naapurit on läpikäyty.\n",
       "#help": "Ohje",
-      "#about": "Lisätietoa"
+      "#about": "Lisätietoa", 
+      "reset": "Uusi Tehtävä"
     }
   },
   "params": {

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.css
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.css
@@ -1,0 +1,27 @@
+#container {
+  width: 800px;
+  height: 595px;
+}
+.jsavline {
+  height: 45px;
+  margin: 0 0 0 20px;
+}
+
+#procontrols {
+  text-align: center;
+}
+
+.jsavgraph svg {
+  z-index: 0;
+}
+
+.jsavnode.marked {
+  background-color: #FFF050;
+}
+.jsavedge {
+  stroke-width: 8;
+  stroke: #7D8879;
+}
+.jsavedge.marked {
+  stroke: #F6B611;
+}

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.css
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.css
@@ -16,12 +16,12 @@
 }
 
 .jsavnode.marked {
-  background-color: #FFF050;
+  background-color: #ffe100;
 }
 .jsavedge {
   stroke-width: 8;
-  stroke: #7D8879;
+  stroke: #d1c39d;
 }
 .jsavedge.marked {
-  stroke: #F6B611;
+  stroke: #ffe100;
 }

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.html
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Depth First Search Algorithm Proficiency Exercise</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="../../JSAV/css/JSAV.css" type="text/css" />
+    <link rel="stylesheet" href="../../lib/odsaAV-min.css" type="text/css" />
+    <link rel="stylesheet" href="graphDFSPE.css" />
+  </head>
+  <body>
+    <div id="container">
+      <table class="proHeaderTable">
+        <tr>
+          <td class="headerLeft">
+            <input type="button" id="help" name="help" value="Help" />
+          </td>
+          <td class="headerCenter">
+            <p class="jsavexercisecontrols"></p>
+          </td>
+          <td class="headerRight">
+            <input type="button" id="about" name="about" value="About" />
+            <a id="settings" class="jsavsettings" href="#">Settings</a>
+          </td>
+        </tr>
+      </table>
+      <form class="avcontainer">
+        <div class="jsavcanvas">
+          <p class="instructLabel"></p>
+          <p class="instructions"></p>
+          <p id="procontrols">
+            <span class="jsavscore"></span>
+          </p>
+        </div>
+      </form>
+    </div>
+    <script src="../../lib/jquery.min.js"></script>
+    <script src="../../lib/jquery-ui.min.js"></script>
+    <script src="../../JSAV/lib/jquery.transit.js"></script>
+    <script src="../../JSAV/lib/raphael.js"></script>
+    <script src="../../JSAV/build/JSAV-min.js"></script>
+    <script src="../../DataStructures/binaryheap.js"></script>
+    <script src="../../lib/odsaUtils-min.js"></script>
+    <script src="../../lib/odsaAV-min.js"></script>
+    <script src="graphUtils.js"></script>
+    <script src="graphDFSPE.js"></script>
+  </body>
+</html>

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.js
@@ -114,7 +114,7 @@
     var i;
     // create the model
     var modelGraph = modeljsav.ds.graph({
-      width: 400,
+      width: 500,
       height: 400,
       layout: "automatic",
       directed: false

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.js
@@ -190,6 +190,7 @@
   exercise = jsav.exercise(model, init, {
     compare: { class: "marked" },
     controls: $('.jsavexercisecontrols'),
+    resetButtonTitle: interpret("reset"),
     fix: fixState
   });
   exercise.reset();

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.js
@@ -1,0 +1,175 @@
+/* global ODSA, graphUtils */
+(function ($) {
+  "use strict";
+  var exercise,
+      graph,
+      config = ODSA.UTILS.loadConfig(),
+      interpret = config.interpreter,
+      settings = config.getSettings(),
+      jsav = new JSAV($('.avcontainer'), {settings: settings});
+
+  jsav.recorded();
+
+  function init_old() {
+    // create the graph
+    if (graph) {
+      graph.clear();
+    }
+    graph = jsav.ds.graph({
+      width: 400,
+      height: 400,
+      layout: "automatic",
+      directed: false
+    });
+    graphUtils.generate(graph); // Randomly generate the graph without weights
+    graph.layout();
+    // mark the 'A' node
+    graph.nodes()[0].addClass("marked");
+
+    jsav.displayInit();
+    return graph;
+  }
+
+  function init() {
+    // Settings for input
+    const width = 500, height = 400,  // pixels
+          weighted = false,
+          directed = false,
+          nVertices = [11, 3],
+          nEdges = [14, 2];
+
+    // First create a random planar graph instance in neighbour list format  
+    let nlGraph = graphUtils.generatePlanarNl(nVertices, nEdges, weighted,
+        directed, width, height);
+
+    // Create a JSAV graph instance
+    if (graph) {
+      graph.clear();
+    }
+    graph = jsav.ds.graph({//    Condition:
+      width: width,
+      height: height,
+      layout: "manual",
+      directed: directed
+    });
+    graphUtils.nlToJsav(nlGraph, graph);
+    graph.layout();
+    graph.nodes()[0].addClass("marked"); // mark the 'A' node
+    jsav.displayInit();
+    return graph;
+  }
+
+  function fixState(modelGraph) {
+    var graphEdges = graph.edges(),
+        modelEdges = modelGraph.edges();
+
+    // compare the edges between exercise and model
+    for (var i = 0; i < graphEdges.length; i++) {
+      var edge = graphEdges[i],
+          modelEdge = modelEdges[i];
+      if (modelEdge.hasClass("marked") && !edge.hasClass("marked")) {
+        // mark the edge that is marked in the model, but not in the exercise
+        markEdge(edge);
+        break;
+      }
+    }
+  }
+
+  function model(modeljsav) {
+    var i;
+    // create the model
+    var modelGraph = modeljsav.ds.graph({
+      width: 400,
+      height: 400,
+      layout: "automatic",
+      directed: false
+    });
+
+    // copy the graph and its weights
+    graphUtils.copy(graph, modelGraph, {weights: true});
+    var modelNodes = modelGraph.nodes();
+
+    // Mark the 'A' node
+    modelNodes[0].addClass("marked");
+
+    modeljsav.displayInit();
+
+    // start the algorithm
+    dfs(modelNodes[0], modeljsav);
+
+    modeljsav.umsg(interpret("av_ms_final"));
+    // hide all edges that are not part of the search tree
+    var modelEdges = modelGraph.edges();
+    for (i = 0; i < modelGraph.edges().length; i++) {
+      if (!modelEdges[i].hasClass("marked")) {
+        modelEdges[i].hide();
+      }
+    }
+
+    modeljsav.step();
+
+    return modelGraph;
+  }
+
+  function markEdge(edge, av) {
+    edge.addClass("marked");
+    edge.start().addClass("marked");
+    edge.end().addClass("marked");
+    if (av) {
+      av.gradeableStep();
+    } else {
+      exercise.gradeableStep();
+    }
+  }
+
+  function dfs(start, av) {
+    var adjacent = start.neighbors();
+    //Sort the neighbors according to their value
+    adjacent.sort(function (a, b) {
+      return a.value().charCodeAt(0) - b.value().charCodeAt(0);
+    });
+    for (var next = adjacent.next(); next; next = adjacent.next()) {
+      av.umsg(interpret("av_ms_process_edge"), {fill: {from: start.value(), to: next.value()}});
+      if (next.hasClass("marked")) {
+        av.umsg(interpret("av_ms_already_visited"), {
+          preserve: true,
+          fill: {
+            node: next.value()
+          }
+        });
+      }
+      av.step();
+      if (!next.hasClass("marked")) {
+        markEdge(start.edgeTo(next), av);
+        dfs(next, av);
+      }
+    }
+  }
+
+
+  // Process About button: Pop up a message with an Alert
+  function about() {
+    window.alert(ODSA.AV.aboutstring(interpret(".avTitle"), interpret("av_Authors")));
+  }
+
+  exercise = jsav.exercise(model, init, {
+    compare: { class: "marked" },
+    controls: $('.jsavexercisecontrols'),
+    fix: fixState
+  });
+  exercise.reset();
+
+  $(".jsavcontainer").on("click", ".jsavedge", function () {
+    var edge = $(this).data("edge");
+    if (!edge.hasClass("marked")) {
+      markEdge(edge);
+    }
+  });
+
+  $(".jsavcontainer").on("click", ".jsavnode", function () {
+    window.alert("Please, click on the edges, not the nodes.");
+  });
+
+  $("#about").click(about);
+
+}(jQuery));

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.js
@@ -42,6 +42,13 @@
     let nlGraph = graphUtils.generatePlanarNl(nVertices, nEdges, weighted,
         directed, width, height);
 
+    // Assure that the random planar graph has A connected to another node
+    // and a sufficiently large spanning tree, i.e. at least 7 edges
+    while (spanning_tree(nlGraph).length < 7) {
+      console.warn("TOO SMALL SPANNING TREE:", spanning_tree(nlGraph).length);
+      nlGraph = graphUtils.generatePlanarNl(nVertices, nEdges, weighted, directed, width, height);
+    }
+
     // Create a JSAV graph instance
     if (graph) {
       graph.clear();
@@ -57,6 +64,34 @@
     graph.nodes()[0].addClass("marked"); // mark the 'A' node
     jsav.displayInit();
     return graph;
+  }
+
+  /**
+   * Calculate the spanning tree for the nlGraph. This is used to ensure
+   * that the spanning tree is sufficiently large and the exercise is not
+   * trivially easy. 
+   * The spanning tree is calculated using the BFS algorithm. 
+   * @param nlGraph as returned by graphUtils.js
+   * @returns spanning tree edge list
+   */
+  function spanning_tree(nlGraph) {
+    let visited = [];
+    let queue = [];
+    let edges = []; //Edges selected in the bfs spanning tree.
+    let node = 0;
+    queue.push(node);
+
+    while (queue.length > 0) {
+      node = queue.shift();
+      visited.push(node);
+      for (const neighbor of nlGraph.edges[node]) {
+        if (!visited.includes(neighbor.v) && !queue.includes(neighbor.v)) {
+          queue.push(neighbor.v);
+          edges.push([node, neighbor.v]);
+        }
+      }
+    }
+    return edges;
   }
 
   function fixState(modelGraph) {

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.json
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.json
@@ -1,0 +1,30 @@
+{
+  "translations" :{
+    "en": {
+      ".avTitle": "Depth-First Search Proficiency Exercise",
+      "av_Authors": "Mohammed Fawzi, Kasper Hellström",
+      ".instructLabel": "Instructions:",
+      ".instructions": "Reproduce the behavior of the DFS algorithm for the graph below. Just click on the <strong>edges</strong> in the order that they will be traversed by the DFS algorithm. Start with Node A. If there is more than one node that could be visited next, choose the one that comes first in alphabetical order.",
+      "av_ms_final": "Final DFS graph",
+      "av_ms_process_edge": "Process edge ({from}, {to}).",
+      "av_ms_already_visited": " Node {node} already visited",
+      "#help": "Help",
+      "#about": "About"
+    },
+    "fi": {
+      ".avTitle": "Syvyyssuuntainen haku",
+      "av_Authors": "Mohammed Fawzi, Kasper Hellström",
+      ".instructLabel": "Ohjeet:",
+      ".instructions": "Käy läpi verkko DFS-järjestyksessä. Aloita läpikäynti solmusta A. Klikkaa <strong>särmiä</strong> samassa järjestyksessä kuin DFS-algoritmi käy ne läpi. Solmun naapurit käydään läpi aakkosjärjestyksessä.",
+      "av_ms_final": "DFS-algoritmin virityspuu",
+      "av_ms_process_edge": "Prosessoidaan särmää ({from}, {to}).",
+      "av_ms_already_visited": " Solmu {node} on jo läpikäyty",
+      "#help": "Ohje",
+      "#about": "Lisätietoa"
+    }
+  },
+  "params": {
+    "JXOP-feedback": "continuous",
+    "JXOP-fixmode": "fix"
+  }
+}

--- a/testbench/OpenDSA/AV/Development/graphDFSPE.json
+++ b/testbench/OpenDSA/AV/Development/graphDFSPE.json
@@ -9,7 +9,8 @@
       "av_ms_process_edge": "Process edge ({from}, {to}).",
       "av_ms_already_visited": " Node {node} already visited",
       "#help": "Help",
-      "#about": "About"
+      "#about": "About", 
+      "reset": "New Exercise"
     },
     "fi": {
       ".avTitle": "Syvyyssuuntainen haku",
@@ -20,7 +21,8 @@
       "av_ms_process_edge": "Prosessoidaan särmää ({from}, {to}).",
       "av_ms_already_visited": " Solmu {node} on jo läpikäyty",
       "#help": "Ohje",
-      "#about": "Lisätietoa"
+      "#about": "Lisätietoa",
+      "reset": "Uusi Tehtävä"
     }
   },
   "params": {


### PR DESCRIPTION
Resolve #137 and #138 . 

BFS and DFS now have a spanning tree of at least 7 edges. This
means that the graphs are no longer trivially easy, or that A is
disconnected from the rest of the graph.

-----------

Resolve #156 : 

The model answer was cut off on the right side as the model answer
had the graph instance being 400 px wide, whereas the exercise is
based on 500 px wide. As such, when copying over from the exercise
it cuts off part of it.

The model answer now has the same width as the exercise.

-----------
Edge colouration consistency and reset button text: 
#151 & #152 

BFS and DFS:
- The edge and node colouration are now consistent with the other
graph exercises
- The reset button now has the text "Uusi tehtävä"/"new exercise"