### PR TITLE
Radix trie: resolve canvas size being too small

### DIFF
--- a/testbench/OpenDSA/AV/Development/ClickHandler.js
+++ b/testbench/OpenDSA/AV/Development/ClickHandler.js
@@ -1,0 +1,586 @@
+(function ($) {
+	"use strict";
+
+	/*
+	 * JSAV click handler for handling moving and copying between different structures
+	 *
+	 * Move currently works with arrays and lists
+	 *
+	 * Copy and Swap behave strangly with lists
+	 *
+	 *
+	 *
+	*/
+	var ClickHandler = function ClickHandler(jsav, exercise, options) {
+		var defaults = {
+			// the class which is given to a node/index when it is selected
+			selectedClass: "jsavhighlight",
+			// ignore all clicks on nodes with this class
+			inactiveClass: undefined,
+			// don't allow selecting empty nodes
+			selectEmpty: false,
+			// move, copy, swap, toss
+			effect: "move",
+			// options for array swap
+			arraySwapOptions: {
+				use: true,				// use array swap by default
+				arrow: false,			// turn array swap arrow off by default
+				highlight: false,		// do not use pink highlighting when swapping
+				swapClasses: true
+			},
+			// remove nodes when they become empty
+			removeNodes: true,
+			// tells click handler if action should be graded. Can be overridden with return value of onDrop.
+			gradeable: true,
+			// allow deselecting by clicking on the background
+			bgDeselect: true,
+			// click, first, last
+			select: "click",
+			// click, first, last
+			drop: "click",
+			// don't allow selecting the last node
+			keep: false,
+			// called by structure when something is selected. If the function returns false, the selection is cancelled
+			onSelect: function () {},
+			// called by structure when something is already selected and another node/index is clicked. If the function returns false, the drop will not take place.
+			beforeDrop: function () {},
+			// called by structure when value has been changed. The return value determins if the step is gradeable. If nothing is returned gradeable will be used.
+			onDrop: function () {}
+		};
+
+		this.jsav = jsav;
+		this.exercise = exercise;
+		this.selStruct = jsav.variable(-1);
+		this.selIndex = jsav.variable(-1);
+		this.selNode = null;	//only valid when selStruct != -1 and selIndex = -1
+		this.ds = [];
+		this.options = $.extend({}, defaults, options);
+
+		if (this.options.bgDeselect) {
+			var ch = this;
+			this.jsav.container.click(function (event) {
+				var $target = $(event.target);
+				if ($target.is(ch.jsav.container) ||
+					$target.is(ch.jsav.canvas) ||
+					$target.is("p")) {
+					ch.deselect();
+				}
+			});
+		}
+	};
+
+	ClickHandler.prototype = {
+		//get the index of a structure
+		getDsIndex: function (ds) {
+			return $.inArray(ds, this.ds);
+		},
+
+		//get a structure 
+		getDs: function (index) {
+			return this.ds[index];
+		},
+
+		//returns an object containing selected structure, index and node (if they exist)
+		getSelected : function () {
+			return {
+				struct: this.getDs(this.selStruct.value()),
+				index: this.selIndex.value(),
+				node: this.selNode
+			};
+		},
+
+		//reset the click handler, but keeps datastructures and settings
+		//should be done when initializing an exercise
+		reset: function () {
+			this.selStruct.value(-1);
+			this.selIndex.value(-1);
+			this.selNode = null;
+		},
+
+		//remove structure from click handler
+		remove: function (ds) {
+			if (this.getDsIndex(ds) === -1) {
+				return false;
+			} else {
+				this.ds.splice(this.getDsIndex(ds), 1);
+				return true;
+			}
+		},
+
+		step: function (grade) {
+			if (grade) {
+				this.exercise.gradeableStep();
+			} else {
+				this.jsav.step();
+			}
+		},
+
+		//tells click handler to select the given index in an array or the given node
+		select: function (struct, indexOrNode) {
+			//don't do anything if click handler is unaware of structure
+			if (this.getDsIndex(struct) === -1) {
+				return;
+			}
+			//deselect if something is selected
+			if (this.getSelected().struct) {
+				this.deselect();
+			}
+
+			if (typeof indexOrNode === "number") {
+				//select array
+				struct.addClass(indexOrNode, this.options.selectedClass);
+				this.selIndex.value(indexOrNode);
+			} else {
+				//select node
+				indexOrNode.addClass(this.options.selectedClass);
+				this.selNode = indexOrNode;
+				this.selIndex.value(-1);
+			}
+			this.selStruct.value(this.getDsIndex(struct));
+		},
+
+		//deselect the selected node
+		deselect: function () {
+			if (this.selStruct.value() !== -1) {
+				if (this.selIndex.value() === -1) {
+					//deselect node
+					if (this.selNode) {
+						this.selNode.removeClass(this.options.selectedClass);
+					}
+				} else {
+					//deselect from array
+					this.getDs(this.selStruct.value()).removeClass(this.selIndex.value(), this.options.selectedClass);
+				}
+				this.reset();
+			}
+		},
+
+		//add an array to the click handler
+		addArray: function (array, options) {
+			//push array into ds
+			this.ds.push(array);
+
+			options = $.extend({}, this.options, options);
+
+			var ch = this;
+
+			//add click handler
+			array.click(function (index) {
+				// ignore the click if the node has the inactive class
+				if (options.inactiveClass && array.hasClass(index, options.inactiveClass)) {
+					return;
+				}
+				//move the values from the JSAV variables into regulas js vars
+				var sStruct = ch.selStruct.value();
+				var sIndex = ch.selIndex.value();
+				var grade, continueDrop;
+
+				if (sStruct === -1) {
+					//select empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value(index) === "") {
+						return;
+					}
+					//call onSelect function
+					var continueSelect = options.onSelect.call(this, index);
+					//return if onSelect returns false
+					if (typeof continueSelect !== "undefined" && !continueSelect) {
+						return;
+					}
+					//mark as selected
+					ch.select(array, index);
+				} else if (sStruct === ch.getDsIndex(this)) {
+					//swap with empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value(index) === "" && ch.options.effect === "swap") {
+						return;
+					}
+					if (sIndex !== index) {
+						//return if beforeDrop returns false
+						continueDrop = options.beforeDrop.call(this, index);
+						if (typeof continueDrop !== "undefined" && !continueDrop) {
+							return;
+						}
+						//move/copy/swap within the array
+						valueEffect(ch, {
+							from: ch.getDs(sStruct),
+							fromIndex: sIndex,
+							to: ch.getDs(sStruct),
+							toIndex: index,
+							effect: options.effect
+						});
+						array.layout();
+						//call onDrop function
+						grade = options.onDrop.call(this, index);
+						if (typeof grade === "undefined") {
+							//use default if nothing is returned
+							grade = options.gradeable;
+						} else {
+							//convert to boolean
+							grade = !!grade;
+						}
+					}
+					//deselect
+					ch.deselect();
+					//mark step unless we were deselecting
+					if (sIndex !== index) {
+						ch.step(grade);
+					}
+				} else {
+					//move/copy/swap from an another structure
+					//swap with empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value(index) === "" && ch.options.effect === "swap") {
+						return;
+					}
+					//return if beforeDrop returns false
+					continueDrop = options.beforeDrop.call(this, index);
+					if (typeof continueDrop !== "undefined" && !continueDrop) {
+						return;
+					}
+					//move value from node (sIndex === -1) or another array
+					valueEffect(ch, {
+						from: sIndex === -1 ? ch.selNode : ch.getDs(sStruct),
+						fromIndex: sIndex === -1 ? undefined : sIndex,
+						to: this,
+						toIndex: index,
+						effect: options.effect
+					});
+					array.layout();
+					//call onDrop function
+					grade = options.onDrop.call(this, index);
+					if (typeof grade === "undefined") {
+						//use default if nothing is returned
+						grade = options.gradeable;
+					} else {
+						//convert to boolean
+						grade = !!grade;
+					}
+					//deselect
+					ch.deselect();
+					//mark step
+					ch.step(grade);
+				}
+			});
+		},
+
+		//add a list to the click handler
+		addList: function (list, options) {
+			//push array into ds
+			this.ds.push(list);
+
+			options = $.extend({}, this.options, options);
+
+			var ch = this;
+
+			//add click handler
+			list.click(function () {
+				// ignore the click if the node has the inactive class
+				if (options.inactiveClass && this.hasClass(options.inactiveClass)) {
+					return;
+				}
+				//move the values from the JSAV variables into regulas js vars
+				var sStruct = ch.selStruct.value();
+				var sIndex = ch.selIndex.value();
+				var grade, continueDrop, to;
+
+				if (sStruct === -1) {
+					//select empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value() === "" && options.select === "click") {
+						return;
+					}
+					//don't allow to select the last node if keep is true
+					if (options.keep && list.size() === 1) {
+						return;
+					}
+					//choose possible selected node
+					var sel;
+					switch (options.select) {
+					case "first":
+						sel = list.first();
+						break;
+					case "last":
+						sel = list.last();
+						break;
+					default: //"click"
+						sel = this;
+					}
+					//call onSelect function
+					var continueSelect = options.onSelect.call(sel);
+					//return if onSelect returns false
+					if (typeof continueSelect !== "undefined" && !continueSelect) {
+						return;
+					}
+					//select
+					ch.select(list, sel);
+				} else if (sStruct === ch.getDsIndex(list)) {
+					switch (options.drop) {
+					case "first":
+						if (options.select === "first" || this === ch.selNode) {
+							to = list.first();
+							break;
+						}
+						to = list.addFirst().first();
+						break;
+					case "last":
+						if (options.select === "last" || this === ch.selNode) {
+							to = list.last();
+							break;
+						}
+						to = list.addLast().last();
+						break;
+					default: //"click"
+						to = this;
+					}
+					if (to !== ch.selNode && this !== ch.selNode) {
+						//return if beforeDrop returns false
+						continueDrop = options.beforeDrop.call(to);
+						if (typeof continueDrop !== "undefined" && !continueDrop) {
+							return;
+						}
+						//move/copy/swap within the list
+						valueEffect(ch, {
+							from: ch.selNode,
+							to: to,
+							effect: options.effect
+						});
+						list.layout();
+						//call onDrop function
+						grade = options.onDrop.call(to);
+						if (typeof grade === "undefined") {
+							//use default if nothing is returned
+							grade = options.gradeable;
+						} else {
+							//convert to boolean
+							grade = !!grade;
+						}
+					}
+					//deselect
+					ch.deselect();
+					//mark step unless only deselecting
+					if (typeof grade !== "undefined") {
+						ch.step(grade);
+					}
+				} else {
+					//move/copy/swap from an another structure
+					switch (options.drop) {
+					case "first":
+						to = list.addFirst().first();
+						break;
+					case "last":
+						to = list.addLast().last();
+						break;
+					default: //"click"
+						to = this;
+					}
+					//return if beforeDrop returns false
+					continueDrop = options.beforeDrop.call(to);
+					if (typeof continueDrop !== "undefined" && !continueDrop) {
+						return;
+					}
+					//move value from node (sIndex === -1) or an array
+					valueEffect(ch, {
+						from: sIndex === -1 ? ch.selNode : ch.getDs(sStruct),
+						fromIndex: sIndex === -1 ? undefined : sIndex,
+						to: to,
+						effect: options.effect
+					});
+					list.layout();
+					//call onDrop function
+					grade = options.onDrop.call(to);
+					if (typeof grade === "undefined") {
+						//use default if nothing is returned
+						grade = options.gradeable;
+					} else {
+						//convert to boolean
+						grade = !!grade;
+					}
+					//deselect
+					ch.deselect();
+					//mark step
+					ch.step(grade);
+				}
+			});
+		},
+
+		//add a (binary) tree to the click handler
+		addTree: function (tree, options) {
+			//push array into ds
+			this.ds.push(tree);
+
+			options = $.extend({}, this.options, options);
+
+			var ch = this;
+
+			//add click handler
+			tree.click(function () {
+				// ignore the click if the node has the inactive class
+				if (options.inactiveClass && this.hasClass(options.inactiveClass)) {
+					return;
+				}
+				//move the values from the JSAV variables into regulas js vars
+				var sStruct = ch.selStruct.value();
+				var sIndex = ch.selIndex.value();
+				var grade, continueDrop;
+
+				if (sStruct === -1) {
+					//select empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value() === "" && options.select === "click") {
+						return;
+					}
+					//don't allow to select the last node if keep is true
+					if (options.keep && tree.height() === 1) {
+						return;
+					}
+					//call onSelect function
+					var continueSelect = options.onSelect.call(this);
+					//return if onSelect returns false
+					if (typeof continueSelect !== "undefined" && !continueSelect) {
+						return;
+					}
+					//select
+					ch.select(tree, this);
+				} else if (sStruct === ch.getDsIndex(tree)) {
+					if (this !== ch.selNode) {
+						//return if beforeDrop returns false
+						continueDrop = options.beforeDrop.call(this);
+						if (typeof continueDrop !== "undefined" && !continueDrop) {
+							return;
+						}
+						//move/copy/swap within the tree
+						valueEffect(ch, {
+							from: ch.selNode,
+							to: this,
+							effect: options.effect
+						});
+						tree.layout();
+						//call onDrop function
+						grade = options.onDrop.call(this);
+						if (typeof grade === "undefined") {
+							//use default if nothing is returned
+							grade = options.gradeable;
+						} else {
+							//convert to boolean
+							grade = !!grade;
+						}
+					}
+					//deselect
+					ch.deselect();
+					if (typeof grade !== "undefined") {
+						ch.step(grade);
+					}
+				} else {
+					//move/copy/swap from an another structure
+					//return if beforeDrop returns false
+					continueDrop = options.beforeDrop.call(this);
+					if (typeof continueDrop !== "undefined" && !continueDrop) {
+						return;
+					}
+					//move value from node (sIndex === -1) or an array
+					valueEffect(ch, {
+						from: sIndex === -1 ? ch.selNode: ch.getDs(sStruct),
+						fromIndex: sIndex === -1 ? undefined: sIndex,
+						to: this,
+						effect: options.effect
+					});
+					tree.layout();
+					//call onDrop function
+					grade = options.onDrop.call(this);
+					if (typeof grade === "undefined") {
+						//use default if nothing is returned
+						grade = options.gradeable;
+					} else {
+						//convert to boolean
+						grade = !!grade;
+					}
+					//deselect
+					ch.deselect();
+					//mark step
+					ch.step(grade);
+				}
+			});
+		}
+	};
+
+	/*
+	 * moves, copies or swaps the elements
+	 */
+	function valueEffect(ch, options) {
+		//create an argument array for apply()
+		var args = valueEffectArguments(options);
+
+		switch (options.effect) {
+		case "move":
+			ch.jsav.effects.moveValue.apply(this, args);
+			break;
+		case "copy":
+			ch.jsav.effects.copyValue.apply(this, args);
+			break;
+		case "swap":
+			if (options.from === options.to &&
+				options.to instanceof JSAV._types.ds.AVArray &&
+				ch.options.arraySwapOptions &&
+				ch.options.arraySwapOptions.use === true)
+			{
+				// remove selected class before swapping, in case the classes are swapped
+				options.from.removeClass(options.fromIndex, ch.options.selectedClass);
+				options.from.swap(options.fromIndex, options.toIndex, ch.options.arraySwapOptions);
+			} else {
+				ch.jsav.effects.swapValues.apply(this, args);
+			}
+			break;
+		case "toss":
+			//remove value from "from structure"
+			if (typeof options.fromIndex === "number") {
+				//remove from array
+				ch.getDs(ch.selStruct.value()).value(ch.selIndex.value(), "");
+			}
+			break;
+		}
+
+		if (ch.options.removeNodes &&
+			$.inArray(options.effect, ["move", "toss"]) !== - 1 &&
+			typeof options.fromIndex === "undefined")
+			{
+			//remove empty node
+			if (ch.getDs(ch.selStruct.value()) instanceof JSAV._types.ds.List) {
+				//remove node from list
+				var list = ch.getDs(ch.selStruct.value());
+				var i;
+				for (i = 0; i < list.size(); i++) {
+					if (list.get(i) === options.from) {
+						list.remove(i);
+						break;
+					}
+				}
+			} else {
+				//TODO: check if this works
+				options.from.remove();
+			}
+			//refresh structures with nodes
+			ch.getDs(ch.selStruct.value()).layout();
+		}
+	}
+
+	//creates an argument array for moveValue/copyValue/swapValue.apply()
+	function valueEffectArguments(options) {
+		if (typeof options.fromIndex !== "undefined") {
+			if (typeof options.toIndex !== "undefined") {
+				//array to array
+				return [options.from, options.fromIndex, options.to, options.toIndex];
+			} else {
+				//array to node
+				return [options.from, options.fromIndex, options.to];
+			}
+		} else {
+			if (typeof options.toIndex !== "undefined") {
+				//node to array
+				return [options.from, options.to, options.toIndex];
+			} else {
+				//node to node
+				return [options.from, options.to];
+			}
+		}
+	}
+
+	if (window) {
+		window.ClickHandler = ClickHandler;
+	}
+}(jQuery));

--- a/testbench/OpenDSA/AV/Development/radixTriePRO.html
+++ b/testbench/OpenDSA/AV/Development/radixTriePRO.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+  <title>Radix Trie</title>
+  <link rel="stylesheet" href="../../JSAV/css/JSAV.css" type="text/css" />
+  <link rel="stylesheet" href="../../lib/odsaAV-min.css" type="text/css" />
+  <link rel="stylesheet" href="proficiency.css" type="text/css" />
+  <link rel="stylesheet" href="trie.css" type="text/css" />
+</head>
+
+<body>
+  <div id="jsavcontainer">
+    <h1 class="exerciseTitle"></h1>
+    <p class="instructLabel"></p>
+    <p class="instructions"></p>
+    <p align="center" class="jsavexercisecontrols"></p>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js"></script>
+  <script src="../../JSAV/lib/jquery.transit.js"></script>
+  <script src="../../JSAV/lib/raphael.js"></script>
+  <script src="../../JSAV/build/JSAV-min.js"></script>
+  <script src="../../JSAV/extras/stack.js"></script>
+  <script src="../../lib/odsaUtils-min.js"></script>
+  <script src="../../lib/odsaAV-min.js"></script>
+  <script src="ClickHandler.js"></script>
+  <script src="radixTriePRO.js"></script>
+</body>
+</html>

--- a/testbench/OpenDSA/AV/Development/radixTriePRO.js
+++ b/testbench/OpenDSA/AV/Development/radixTriePRO.js
@@ -1,0 +1,295 @@
+/* global ODSA, ClickHandler */
+(function ($) {
+  "use strict";
+  JSAV._types.ds.BinaryTreeNode.prototype.createLabel = function (val) {
+    if (this.label) {
+      this.label.clear();
+    }
+    this.label = this.jsav.label(val, {container: this.element});
+    this.label.element.css({
+      left: this.element.outerWidth() - 42,
+      top: - this.label.element.outerHeight() - 5
+    });
+    //set z-index to prevent the label from disappearing behind the edge to its nodes parent node
+    //if z-index < 110 the label disappears behind the edge
+    this.element.css({"z-index": 110});
+  };
+
+  JSAV._types.ds.BinaryTreeNode.prototype.clearLabel = function () {
+    if (!this.label) { return; }
+    this.label.clear();
+  };
+
+  JSAV._types.ds.BinaryTreeNode.prototype.getLabel = function () {
+    return this.label;
+  };
+
+  //modified to remove label when value is empty and create label when it's not empty
+  JSAV._types.ds.BinaryTreeNode.prototype._setvalue = JSAV.anim(function (newValue) {
+    var oldVal = this.value(),
+      valtype = typeof(newValue);
+    if (typeof oldVal === "undefined") { oldVal = ""; }
+    if (valtype === "object") { valtype = "string"; }
+    this.element
+      .removeClass("jsavnullnode")
+      .find(".jsavvalue")
+      .html(this._valstring(newValue))
+      .end()
+      .attr({"data-value": newValue, "data-value-type": valtype});
+    if (newValue === "") {
+      this.clearLabel();
+    } else if (newValue !== "jsavnull") {
+      this.createLabel(getBinary(newValue));
+    }
+    if (newValue === "jsavnull") {
+      this.element.addClass("jsavnullnode");
+    }
+    return [oldVal];
+  });
+
+  // AV varialbles
+  var insertArray,
+      tree,
+      stack,
+      stackLabels,
+      insertSize = 6,
+      clickHandler,
+
+      // Load the configurations created by odsaAV.js
+      config = ODSA.UTILS.loadConfig({"av_container": "jsavcontainer"}),
+      interpret = config.interpreter,
+      code = config.code,
+      codeOptions = {after: {element: $(".instructions")}, visible: true, lineNumbers: false},
+
+      // Create a JSAV instance
+      av = new JSAV($("#jsavcontainer"));
+
+  av.recorded(); // we are not recording an AV with an algorithm
+
+  if (code) {
+    av.code(code[1], codeOptions);
+    av.code(code[0], codeOptions);
+  }
+
+  function initialize() {
+
+    av.container.find(".jsavcanvas").css("min-height", 450);
+
+    if (typeof clickHandler === "undefined") {
+      clickHandler = new ClickHandler(av, exercise, {
+        selectedClass: "selected",
+        removeNodes: false,
+        selectEmpty: true
+      });
+    }
+    clickHandler.reset();
+
+    //generate values. 65 = A, 80 = 0
+    insertArray = generateValues(insertSize, 65, 80);
+    //convert the values into characters and push them into the stack
+    var i;
+    for (i = 0; i < insertSize; i++) {
+      insertArray[i] = String.fromCharCode(insertArray[i]);
+      // stack.addLast(insertArray[i]);
+    }
+    //clear the old stack
+    if (stack) {
+      clickHandler.remove(stack);
+      stack.clear();
+    }
+    //create a new stack
+    stack = av.ds.stack(insertArray, {center: true});
+    stack.layout();
+    clickHandler.addList(stack, {
+      select: "first",
+      drop: "first",
+      keep: false
+    });
+
+    //contains references to the labels of the stack nodes
+    stackLabels = [];
+    //put labels on the stack nodes and hide all except the first one by default
+    for (i = 0; i < insertSize; i++) {
+      var l = av.label(getBinary(insertArray[i]), {container: stack.get(i).element, visible: i === 0});
+      l.element.css({
+        left: stack.last().element.outerWidth() - 42,
+        top: - l.element.outerHeight() - 5
+      });
+      stackLabels.push(l);
+    }
+
+    //clear the old tree
+    if (tree) {
+      clickHandler.remove(tree);
+      tree.clear();
+    }
+    //create a new tree
+    tree = av.ds.binarytree({center: true, visible: true, nodegap: 15});
+    tree.root("");
+    tree.root().addClass("emptynode");
+    tree.layout();
+    clickHandler.addTree(tree, {
+      onSelect: function () {
+        // select the value if
+        if (this.value()) {
+          return true;
+        }
+        // don't continue (and don't select the node) if it doesn't have the class "emptynode"
+        if (!this.hasClass("emptynode")) {
+          return false;
+        }
+        // The user has clicked on an empty node, so we remove the empty node class and give the node two children
+        this.removeClass("emptynode");
+        this.left("");
+        this.left().element.addClass("emptynode");
+        this.right("");
+        this.right().element.addClass("emptynode");
+        // call layout function for the tree
+        this.container.layout();
+        exercise.gradeableStep();
+        // don't select the node
+        return false;
+      },
+      onDrop: function () {
+        this.removeClass("emptynode");
+        if (!this.left()) {
+          //add empty node on the left side
+          this.left("");
+          this.left().element.addClass("emptynode");
+        }
+        if (!this.right()) {
+          //add empty node on the right side
+          this.right("");
+          this.right().element.addClass("emptynode");
+        }
+        this.container.layout();
+        if (stack.first() && !stack.first().value()) {
+          stack.removeFirst();
+        }
+        if (stack.size()) {
+          stackLabels[insertSize - stack.size()].show();
+        }
+        stack.layout();
+      }
+    });
+
+    return tree;
+  }
+
+  function modelSolution(jsav) {
+    jsav._undo = [];
+
+    var modelStack = jsav.ds.stack(insertArray, {center: true});
+    modelStack.layout();
+    var l = jsav.label(getBinary(insertArray[0]), { container: modelStack.first().element });
+    l.element.css({
+      left: modelStack.first().element.outerWidth() - 42,
+      top: - l.element.outerHeight() - 5
+    });
+
+    var modelTree = jsav.ds.binarytree({center: true, visible: true, nodegap: 10});
+    modelTree.root("");
+    modelTree.root().addClass("emptynode");
+    modelTree.layout();
+
+    jsav.displayInit();
+
+    for (var i = 0; i < insertSize; i++) {
+      var val = getBinary(insertArray[i]);
+      var level = 0;
+      var node = modelTree.root();
+      //find the node where the value should be inserted
+      while (!node.hasClass("emptynode") && node.value() === "") {
+        if (val.charAt(level) === "0") {
+          node = node.left();
+        } else {
+          node = node.right();
+        }
+        level += 1;
+      }
+      if (node.hasClass("emptynode")) {
+        //insert value and add empty nodes
+        node.value(insertArray[i]);
+        node.left("");
+        node.left().element.addClass("emptynode");
+        node.right("");
+        node.right().element.addClass("emptynode");
+        node.removeClass("emptynode");
+      } else {
+        // level += 1;
+        while (val.charAt(level) === getBinary(node.value()).charAt(level)) {
+          node = node.child(parseInt(val.charAt(level), 10))
+            .removeClass("emptynode")
+            .value(node.value());
+          node.parent().value("");
+          node.left("");
+          node.left().element.addClass("emptynode");
+          node.right("");
+          node.right().element.addClass("emptynode");
+          level += 1;
+        }
+        //insert value
+        node.child(parseInt(val.charAt(level), 10))
+          .removeClass("emptynode")
+          .value(insertArray[i])
+          .left("")
+          .element.addClass("emptynode");
+        node.child(parseInt(val.charAt(level), 10))
+          .right("")
+          .element.addClass("emptynode");
+        //move value from node to the sibling of the newly inserted node
+        node.child(1 - parseInt(val.charAt(level), 10))
+          .removeClass("emptynode")
+          .value(node.value())
+          .left("")
+          .element.addClass("emptynode");
+        node.child(1 - parseInt(val.charAt(level), 10))
+          .right("")
+          .element.addClass("emptynode");
+        node.value("");
+      }
+
+      modelTree.layout();
+      modelStack.removeFirst();
+      modelStack.layout();
+      if (modelStack.first()) {
+        //add label to stack node
+        l = jsav.label(getBinary(insertArray[i + 1]), {container: modelStack.first().element});
+        l.element.css({
+          left: modelStack.first().element.outerWidth() - 42,
+          top: - l.element.outerHeight() - 5
+        });
+      }
+
+      jsav.stepOption("grade", true);
+      jsav.step();
+    }
+
+    return modelTree;
+  }
+
+  //generate values without duplicates
+  function generateValues(n, min, max) {
+    var arr = [];
+    var val;
+    for (var i = 0; i < n; i++) {
+      do {
+        val = Math.floor(min + Math.random() * (max - min));
+      } while ($.inArray(val, arr) !== -1);
+      arr.push(val);
+    }
+    return arr;
+  }
+
+  function getBinary(char) {
+    var binLen = 4;
+    if (typeof char === "string") {
+      char = char.charCodeAt(0);
+    }
+    return new Array(binLen + 1 - (char % 64).toString(2).length).join("0") + (char % 64).toString(2);
+  }
+
+  var exercise = av.exercise(modelSolution, initialize, {feedback: "atend", grader: "finder"});
+  exercise.reset();
+
+}(jQuery));

--- a/testbench/OpenDSA/AV/Development/radixTriePRO.js
+++ b/testbench/OpenDSA/AV/Development/radixTriePRO.js
@@ -73,7 +73,7 @@
 
   function initialize() {
 
-    av.container.find(".jsavcanvas").css("min-height", 450);
+    av.container.find(".jsavcanvas").css("min-height", 490);
 
     if (typeof clickHandler === "undefined") {
       clickHandler = new ClickHandler(av, exercise, {

--- a/testbench/OpenDSA/AV/Development/radixTriePRO.json
+++ b/testbench/OpenDSA/AV/Development/radixTriePRO.json
@@ -1,0 +1,55 @@
+{
+  "translations" :{
+    "en": {
+      ".exerciseTitle": "Radix Search Trie",
+      "av_Authors": "Kasper Hellström",
+      ".instructLabel": "Instructions:",
+      ".instructions": "Insert the given keys into the initially empty radix search trie."
+    },
+    "fi": {
+      ".exerciseTitle": "Radix hakupuu",
+      "av_Authors": "Kasper Hellström",
+      ".instructLabel": "Ohjeet:",
+      ".instructions": "Lisää pinon avaimet annetussa järjestyksessä alla olevaan radix-hakupuuhun."
+    }
+  },
+  "code": {
+    "english": [
+      [
+        "INSERT:",
+        "1. Search the correct position",
+        "2. If the position is an empty node, insert the new key here to be a leaf node",
+        "3. If there already was a leaf node, the node itself becomes an inner node,",
+        "   and below this the tree should make distinction between the old leaf",
+        "   and the new node",
+        "4. Finally, new leaf nodes appear for the old leaf and the new node."
+      ],
+      [
+        "SEARCH:",
+        "1. Start from the root node and the most significant bit",
+        "2. Proceed bit-by-bit turning either into the left (0) or right based on",
+        "   the current bit until a leaf node is encountered",
+        "3. Check whether the key to be searched is in this leaf node"
+      ]
+    ],
+    "finnish": [
+      [
+        "INSERT:",
+        "1. Haetaan alkion paikka bittien perusteella",
+        "2. Jos löydetty paikka oli tyhjä, lisätään alkio tähän kohtaan puun lehdeksi",
+        "3. Jos paikassa oli lehti, tästä tulee puun sisäsolmu ja sen alle rakennetaan",
+        "   alipuu tai alipuut siten, että lehdessä ollut avain ja lisättävä avain",
+        "   eroavat toisistaan",
+        "4. Luodaan uudet lehtisolmut, joihin em. vanhan lehden avain ja lisättävä",
+        "   avain talletetaan"
+      ],
+      [
+        "SEARCH:",
+        "1. Aloitetaan juuresta ja eniten merkitsevästä bitistä",
+        "2. Edetään bitti kerrallaan puussa alaspäin kääntyen (0) vasempaan tai",
+        "   (1) oikeaan haaraan, kunnes kohdataan puun lehti",
+        "3. Katsotaan, onko alkio lehdessä"
+      ]
+    ]
+  }
+}

--- a/testbench/OpenDSA/AV/Development/trie.css
+++ b/testbench/OpenDSA/AV/Development/trie.css
@@ -1,0 +1,20 @@
+.jsavtreenode {
+  cursor: pointer;
+}
+.jsavtree {
+  margin-top: 30px;
+}
+.jsavstack {
+  margin-top: 30px;
+}
+.jsavlabel {
+  border: 1px solid #eca;
+  border-radius: 3px;
+  padding: 1px 3px;
+  background-color: #fe8;
+  color: #975;
+  position: absolute;
+  z-index: 101;
+  line-height: normal;
+  font-size: medium;
+}

--- a/testbench/OpenDSA/JSAV/extras/stack.css
+++ b/testbench/OpenDSA/JSAV/extras/stack.css
@@ -1,0 +1,11 @@
+.jsavstack {
+  position: relative;
+  background-color: inherit;
+}
+.jsavstacknode {
+  position: absolute;
+  border-radius: 5px;
+  width: 45px;
+  height: 45px;
+  z-index: 100;
+}

--- a/testbench/OpenDSA/JSAV/extras/stack.js
+++ b/testbench/OpenDSA/JSAV/extras/stack.js
@@ -1,0 +1,171 @@
+(function ($) {
+  "use strict";
+  if (typeof JSAV === "undefined") { return; }
+
+  var Stack = function (jsav, values, options) {
+    this.jsav = jsav;
+    if (!$.isArray(values)) {
+      options = values;
+      values = [];
+    }
+    this.options = $.extend({visible: true, xtransition: 10, ytransition: -5, autoresize: true}, options);
+    var el = this.options.element || $("<div/>");
+    el.addClass("jsavstack");
+    for (var key in this.options) {
+      var val = this.options[key];
+      if (this.options.hasOwnProperty(key) && typeof(val) === "string" || typeof(val) === "number" || typeof(val) === "boolean") {
+        el.attr("data-" + key, val);
+      }
+    }
+    if (!this.options.element) {
+      $(jsav.canvas).append(el);
+    }
+    this.element = el;
+    this.element.attr({"id": this.id()});
+    if (this.options.autoresize) {
+      el.addClass("jsavautoresize");
+    }
+    for (var i = values.length; i--; ) {
+      this.addFirst(values[i]);
+    }
+    if (values.length > 0) {
+      this.layout();
+    }
+    JSAV.utils._helpers.handlePosition(this);
+    JSAV.utils._helpers.handleVisibility(this, this.options);
+  };
+  JSAV.utils.extend(Stack, JSAV._types.ds.List);
+  var stackproto = Stack.prototype;
+
+  stackproto.newNode = function (value, options) {
+    return new StackNode(this, value, $.extend({first: false}, this.options, options));
+  };
+
+  stackproto.layout = function (options) {
+    var layoutAlg = $.extend({}, this.options, options).layout || "_default";
+    return this.jsav.ds.layout.stack[layoutAlg](this, options);
+  };
+
+  var StackNode = function (container, value, options) {
+    this.jsav = container.jsav;
+    this.container = container;
+    this._next = options.next;
+    this._value = value;
+    this.options = $.extend(true, {visible: true}, options);
+    var el = $("<div><span class='jsavvalue'>" + this._valstring(value) + "</span></div>"),
+      valtype = typeof(value);
+    if (valtype === "object") { valtype = "string"; }
+    this.element = el;
+    el.addClass("jsavnode jsavstacknode")
+        .attr({"data-value": value, "id": this.id(), "data-value-type": valtype })
+        .data("node", this);
+    if ("first" in options && options.first) {
+      this.container.element.prepend(el);
+    } else {
+      this.container.element.append(el);
+    }
+    JSAV.utils._helpers.handleVisibility(this, this.options);
+  };
+  JSAV.utils.extend(StackNode, JSAV._types.ds.ListNode);
+  var stacknodeproto = StackNode.prototype;
+
+
+  stacknodeproto._setnext = JSAV.anim(function (newNext, options) {
+    var oldNext = this._next;
+    this._next = newNext;
+    return [oldNext];
+  });
+
+  stacknodeproto.zIndex = JSAV.anim(function (index) {
+    var oldVal = ~~this.element.css("z-index"),
+        node = this;
+    if (this.jsav._shouldAnimate()) { // only animate when playing, not when recording
+      $({ z: oldVal }).animate({ z: index }, {
+          step: function() {
+              node.element.css('zIndex', ~~this.z);
+          },
+          duration: this.jsav.SPEED
+      });
+    } else {
+      this.element.css("z-index", index);
+    }
+    return [oldVal];
+  });
+
+  var stackLayout = function (stack, options) {
+    var curNode = stack.first(),
+        prevNode,
+        pos = {},
+        xTrans = stack.options.xtransition,
+        yTrans = stack.options.ytransition,
+        opts = $.extend({}, stack.options, options),
+        width = 0,
+        height = 0,
+        left = 0,
+        posData = [],
+        zPos;
+
+    while (curNode) {
+      if (prevNode) {
+        pos = {
+          left: pos.left + xTrans,
+          top: pos.top + yTrans
+        };
+        zPos -= 1;
+        width += Math.abs(xTrans);
+        if ((yTrans < 0 && pos.top < posData[0].nodePos.top) || (yTrans > 0 && pos.top > posData[0].nodePos.top)) {
+          height += Math.abs(yTrans);
+        }
+        if (stack.options.ytransition < 0) {
+          yTrans += 1;
+        }
+      } else {
+        pos = {
+          left: (xTrans < 0? stack.size(): 0) * -xTrans,
+          top: (yTrans < 0? Math.min(stack.size(), -yTrans): 0) * -(yTrans - 1)/2
+        };
+        zPos = stack.size();
+        width = curNode.element.outerWidth();
+        height = curNode.element.outerHeight();
+      }
+      posData.push({node: curNode, nodePos: pos, zPos: zPos});
+
+      prevNode = curNode;
+      curNode = curNode.next();
+    }
+    if (stack.size() === 0) {
+      var tmpNode = stack.newNode("");
+      width = tmpNode.element.outerWidth();
+      height = tmpNode.element.outerHeight();
+      tmpNode.clear();
+    }
+
+    if (stack.options.center) {
+      left = ($(stack.jsav.canvas).width() - width) / 2;
+    } else {
+      left = stack.element.position().left;
+    }
+
+    if (!opts.boundsOnly) {
+      // ..update stack size and position..
+      stack.css({width: width, height: height, left: left});
+      // .. and finally update the node positions
+      // doing the size first makes the animation look smoother by reducing some flicker
+      for (var i = 0; i < posData.length; i++) {
+        var posItem = posData[i];
+        posItem.node.zIndex(posItem.zPos);
+        posItem.node.css(posItem.nodePos);
+      }
+    }
+    return { width: width, height: height, left: left, top: stack.element.position().top };
+  };
+
+  JSAV.ext.ds.layout.stack = {
+    "_default": stackLayout
+  };
+
+  JSAV.ext.ds.stack = function(values, options) {
+    return new Stack(this, values, options);
+  };
+
+}(jQuery));


### PR DESCRIPTION
Resolve https://github.com/Aalto-LeTech/jsav-exercise-recorder/issues/139:
The min-height of the canvas was 450px. As the exercise permits
the tree to go to a depth of 5 nodes + 1 layer of empty nodes,
this was not enough. In that case, the canvas stretches to 487px.
Due to how it is embedded in A+, increasing the exercise height
causes a scrollbar and part of the empty nodes to be cut off.

To resolve this issue, the canvas has been given a minimum height
of 490px. The exercise still fits on a 1080p display.