### PR TITLE
Common Trie: Resolve model answer being too narrow

### DIFF
--- a/testbench/OpenDSA/AV/Development/ClickHandler.js
+++ b/testbench/OpenDSA/AV/Development/ClickHandler.js
@@ -1,0 +1,586 @@
+(function ($) {
+	"use strict";
+
+	/*
+	 * JSAV click handler for handling moving and copying between different structures
+	 *
+	 * Move currently works with arrays and lists
+	 *
+	 * Copy and Swap behave strangly with lists
+	 *
+	 *
+	 *
+	*/
+	var ClickHandler = function ClickHandler(jsav, exercise, options) {
+		var defaults = {
+			// the class which is given to a node/index when it is selected
+			selectedClass: "jsavhighlight",
+			// ignore all clicks on nodes with this class
+			inactiveClass: undefined,
+			// don't allow selecting empty nodes
+			selectEmpty: false,
+			// move, copy, swap, toss
+			effect: "move",
+			// options for array swap
+			arraySwapOptions: {
+				use: true,				// use array swap by default
+				arrow: false,			// turn array swap arrow off by default
+				highlight: false,		// do not use pink highlighting when swapping
+				swapClasses: true
+			},
+			// remove nodes when they become empty
+			removeNodes: true,
+			// tells click handler if action should be graded. Can be overridden with return value of onDrop.
+			gradeable: true,
+			// allow deselecting by clicking on the background
+			bgDeselect: true,
+			// click, first, last
+			select: "click",
+			// click, first, last
+			drop: "click",
+			// don't allow selecting the last node
+			keep: false,
+			// called by structure when something is selected. If the function returns false, the selection is cancelled
+			onSelect: function () {},
+			// called by structure when something is already selected and another node/index is clicked. If the function returns false, the drop will not take place.
+			beforeDrop: function () {},
+			// called by structure when value has been changed. The return value determins if the step is gradeable. If nothing is returned gradeable will be used.
+			onDrop: function () {}
+		};
+
+		this.jsav = jsav;
+		this.exercise = exercise;
+		this.selStruct = jsav.variable(-1);
+		this.selIndex = jsav.variable(-1);
+		this.selNode = null;	//only valid when selStruct != -1 and selIndex = -1
+		this.ds = [];
+		this.options = $.extend({}, defaults, options);
+
+		if (this.options.bgDeselect) {
+			var ch = this;
+			this.jsav.container.click(function (event) {
+				var $target = $(event.target);
+				if ($target.is(ch.jsav.container) ||
+					$target.is(ch.jsav.canvas) ||
+					$target.is("p")) {
+					ch.deselect();
+				}
+			});
+		}
+	};
+
+	ClickHandler.prototype = {
+		//get the index of a structure
+		getDsIndex: function (ds) {
+			return $.inArray(ds, this.ds);
+		},
+
+		//get a structure 
+		getDs: function (index) {
+			return this.ds[index];
+		},
+
+		//returns an object containing selected structure, index and node (if they exist)
+		getSelected : function () {
+			return {
+				struct: this.getDs(this.selStruct.value()),
+				index: this.selIndex.value(),
+				node: this.selNode
+			};
+		},
+
+		//reset the click handler, but keeps datastructures and settings
+		//should be done when initializing an exercise
+		reset: function () {
+			this.selStruct.value(-1);
+			this.selIndex.value(-1);
+			this.selNode = null;
+		},
+
+		//remove structure from click handler
+		remove: function (ds) {
+			if (this.getDsIndex(ds) === -1) {
+				return false;
+			} else {
+				this.ds.splice(this.getDsIndex(ds), 1);
+				return true;
+			}
+		},
+
+		step: function (grade) {
+			if (grade) {
+				this.exercise.gradeableStep();
+			} else {
+				this.jsav.step();
+			}
+		},
+
+		//tells click handler to select the given index in an array or the given node
+		select: function (struct, indexOrNode) {
+			//don't do anything if click handler is unaware of structure
+			if (this.getDsIndex(struct) === -1) {
+				return;
+			}
+			//deselect if something is selected
+			if (this.getSelected().struct) {
+				this.deselect();
+			}
+
+			if (typeof indexOrNode === "number") {
+				//select array
+				struct.addClass(indexOrNode, this.options.selectedClass);
+				this.selIndex.value(indexOrNode);
+			} else {
+				//select node
+				indexOrNode.addClass(this.options.selectedClass);
+				this.selNode = indexOrNode;
+				this.selIndex.value(-1);
+			}
+			this.selStruct.value(this.getDsIndex(struct));
+		},
+
+		//deselect the selected node
+		deselect: function () {
+			if (this.selStruct.value() !== -1) {
+				if (this.selIndex.value() === -1) {
+					//deselect node
+					if (this.selNode) {
+						this.selNode.removeClass(this.options.selectedClass);
+					}
+				} else {
+					//deselect from array
+					this.getDs(this.selStruct.value()).removeClass(this.selIndex.value(), this.options.selectedClass);
+				}
+				this.reset();
+			}
+		},
+
+		//add an array to the click handler
+		addArray: function (array, options) {
+			//push array into ds
+			this.ds.push(array);
+
+			options = $.extend({}, this.options, options);
+
+			var ch = this;
+
+			//add click handler
+			array.click(function (index) {
+				// ignore the click if the node has the inactive class
+				if (options.inactiveClass && array.hasClass(index, options.inactiveClass)) {
+					return;
+				}
+				//move the values from the JSAV variables into regulas js vars
+				var sStruct = ch.selStruct.value();
+				var sIndex = ch.selIndex.value();
+				var grade, continueDrop;
+
+				if (sStruct === -1) {
+					//select empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value(index) === "") {
+						return;
+					}
+					//call onSelect function
+					var continueSelect = options.onSelect.call(this, index);
+					//return if onSelect returns false
+					if (typeof continueSelect !== "undefined" && !continueSelect) {
+						return;
+					}
+					//mark as selected
+					ch.select(array, index);
+				} else if (sStruct === ch.getDsIndex(this)) {
+					//swap with empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value(index) === "" && ch.options.effect === "swap") {
+						return;
+					}
+					if (sIndex !== index) {
+						//return if beforeDrop returns false
+						continueDrop = options.beforeDrop.call(this, index);
+						if (typeof continueDrop !== "undefined" && !continueDrop) {
+							return;
+						}
+						//move/copy/swap within the array
+						valueEffect(ch, {
+							from: ch.getDs(sStruct),
+							fromIndex: sIndex,
+							to: ch.getDs(sStruct),
+							toIndex: index,
+							effect: options.effect
+						});
+						array.layout();
+						//call onDrop function
+						grade = options.onDrop.call(this, index);
+						if (typeof grade === "undefined") {
+							//use default if nothing is returned
+							grade = options.gradeable;
+						} else {
+							//convert to boolean
+							grade = !!grade;
+						}
+					}
+					//deselect
+					ch.deselect();
+					//mark step unless we were deselecting
+					if (sIndex !== index) {
+						ch.step(grade);
+					}
+				} else {
+					//move/copy/swap from an another structure
+					//swap with empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value(index) === "" && ch.options.effect === "swap") {
+						return;
+					}
+					//return if beforeDrop returns false
+					continueDrop = options.beforeDrop.call(this, index);
+					if (typeof continueDrop !== "undefined" && !continueDrop) {
+						return;
+					}
+					//move value from node (sIndex === -1) or another array
+					valueEffect(ch, {
+						from: sIndex === -1 ? ch.selNode : ch.getDs(sStruct),
+						fromIndex: sIndex === -1 ? undefined : sIndex,
+						to: this,
+						toIndex: index,
+						effect: options.effect
+					});
+					array.layout();
+					//call onDrop function
+					grade = options.onDrop.call(this, index);
+					if (typeof grade === "undefined") {
+						//use default if nothing is returned
+						grade = options.gradeable;
+					} else {
+						//convert to boolean
+						grade = !!grade;
+					}
+					//deselect
+					ch.deselect();
+					//mark step
+					ch.step(grade);
+				}
+			});
+		},
+
+		//add a list to the click handler
+		addList: function (list, options) {
+			//push array into ds
+			this.ds.push(list);
+
+			options = $.extend({}, this.options, options);
+
+			var ch = this;
+
+			//add click handler
+			list.click(function () {
+				// ignore the click if the node has the inactive class
+				if (options.inactiveClass && this.hasClass(options.inactiveClass)) {
+					return;
+				}
+				//move the values from the JSAV variables into regulas js vars
+				var sStruct = ch.selStruct.value();
+				var sIndex = ch.selIndex.value();
+				var grade, continueDrop, to;
+
+				if (sStruct === -1) {
+					//select empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value() === "" && options.select === "click") {
+						return;
+					}
+					//don't allow to select the last node if keep is true
+					if (options.keep && list.size() === 1) {
+						return;
+					}
+					//choose possible selected node
+					var sel;
+					switch (options.select) {
+					case "first":
+						sel = list.first();
+						break;
+					case "last":
+						sel = list.last();
+						break;
+					default: //"click"
+						sel = this;
+					}
+					//call onSelect function
+					var continueSelect = options.onSelect.call(sel);
+					//return if onSelect returns false
+					if (typeof continueSelect !== "undefined" && !continueSelect) {
+						return;
+					}
+					//select
+					ch.select(list, sel);
+				} else if (sStruct === ch.getDsIndex(list)) {
+					switch (options.drop) {
+					case "first":
+						if (options.select === "first" || this === ch.selNode) {
+							to = list.first();
+							break;
+						}
+						to = list.addFirst().first();
+						break;
+					case "last":
+						if (options.select === "last" || this === ch.selNode) {
+							to = list.last();
+							break;
+						}
+						to = list.addLast().last();
+						break;
+					default: //"click"
+						to = this;
+					}
+					if (to !== ch.selNode && this !== ch.selNode) {
+						//return if beforeDrop returns false
+						continueDrop = options.beforeDrop.call(to);
+						if (typeof continueDrop !== "undefined" && !continueDrop) {
+							return;
+						}
+						//move/copy/swap within the list
+						valueEffect(ch, {
+							from: ch.selNode,
+							to: to,
+							effect: options.effect
+						});
+						list.layout();
+						//call onDrop function
+						grade = options.onDrop.call(to);
+						if (typeof grade === "undefined") {
+							//use default if nothing is returned
+							grade = options.gradeable;
+						} else {
+							//convert to boolean
+							grade = !!grade;
+						}
+					}
+					//deselect
+					ch.deselect();
+					//mark step unless only deselecting
+					if (typeof grade !== "undefined") {
+						ch.step(grade);
+					}
+				} else {
+					//move/copy/swap from an another structure
+					switch (options.drop) {
+					case "first":
+						to = list.addFirst().first();
+						break;
+					case "last":
+						to = list.addLast().last();
+						break;
+					default: //"click"
+						to = this;
+					}
+					//return if beforeDrop returns false
+					continueDrop = options.beforeDrop.call(to);
+					if (typeof continueDrop !== "undefined" && !continueDrop) {
+						return;
+					}
+					//move value from node (sIndex === -1) or an array
+					valueEffect(ch, {
+						from: sIndex === -1 ? ch.selNode : ch.getDs(sStruct),
+						fromIndex: sIndex === -1 ? undefined : sIndex,
+						to: to,
+						effect: options.effect
+					});
+					list.layout();
+					//call onDrop function
+					grade = options.onDrop.call(to);
+					if (typeof grade === "undefined") {
+						//use default if nothing is returned
+						grade = options.gradeable;
+					} else {
+						//convert to boolean
+						grade = !!grade;
+					}
+					//deselect
+					ch.deselect();
+					//mark step
+					ch.step(grade);
+				}
+			});
+		},
+
+		//add a (binary) tree to the click handler
+		addTree: function (tree, options) {
+			//push array into ds
+			this.ds.push(tree);
+
+			options = $.extend({}, this.options, options);
+
+			var ch = this;
+
+			//add click handler
+			tree.click(function () {
+				// ignore the click if the node has the inactive class
+				if (options.inactiveClass && this.hasClass(options.inactiveClass)) {
+					return;
+				}
+				//move the values from the JSAV variables into regulas js vars
+				var sStruct = ch.selStruct.value();
+				var sIndex = ch.selIndex.value();
+				var grade, continueDrop;
+
+				if (sStruct === -1) {
+					//select empty nodes only if the options allow it
+					if (!options.selectEmpty && this.value() === "" && options.select === "click") {
+						return;
+					}
+					//don't allow to select the last node if keep is true
+					if (options.keep && tree.height() === 1) {
+						return;
+					}
+					//call onSelect function
+					var continueSelect = options.onSelect.call(this);
+					//return if onSelect returns false
+					if (typeof continueSelect !== "undefined" && !continueSelect) {
+						return;
+					}
+					//select
+					ch.select(tree, this);
+				} else if (sStruct === ch.getDsIndex(tree)) {
+					if (this !== ch.selNode) {
+						//return if beforeDrop returns false
+						continueDrop = options.beforeDrop.call(this);
+						if (typeof continueDrop !== "undefined" && !continueDrop) {
+							return;
+						}
+						//move/copy/swap within the tree
+						valueEffect(ch, {
+							from: ch.selNode,
+							to: this,
+							effect: options.effect
+						});
+						tree.layout();
+						//call onDrop function
+						grade = options.onDrop.call(this);
+						if (typeof grade === "undefined") {
+							//use default if nothing is returned
+							grade = options.gradeable;
+						} else {
+							//convert to boolean
+							grade = !!grade;
+						}
+					}
+					//deselect
+					ch.deselect();
+					if (typeof grade !== "undefined") {
+						ch.step(grade);
+					}
+				} else {
+					//move/copy/swap from an another structure
+					//return if beforeDrop returns false
+					continueDrop = options.beforeDrop.call(this);
+					if (typeof continueDrop !== "undefined" && !continueDrop) {
+						return;
+					}
+					//move value from node (sIndex === -1) or an array
+					valueEffect(ch, {
+						from: sIndex === -1 ? ch.selNode: ch.getDs(sStruct),
+						fromIndex: sIndex === -1 ? undefined: sIndex,
+						to: this,
+						effect: options.effect
+					});
+					tree.layout();
+					//call onDrop function
+					grade = options.onDrop.call(this);
+					if (typeof grade === "undefined") {
+						//use default if nothing is returned
+						grade = options.gradeable;
+					} else {
+						//convert to boolean
+						grade = !!grade;
+					}
+					//deselect
+					ch.deselect();
+					//mark step
+					ch.step(grade);
+				}
+			});
+		}
+	};
+
+	/*
+	 * moves, copies or swaps the elements
+	 */
+	function valueEffect(ch, options) {
+		//create an argument array for apply()
+		var args = valueEffectArguments(options);
+
+		switch (options.effect) {
+		case "move":
+			ch.jsav.effects.moveValue.apply(this, args);
+			break;
+		case "copy":
+			ch.jsav.effects.copyValue.apply(this, args);
+			break;
+		case "swap":
+			if (options.from === options.to &&
+				options.to instanceof JSAV._types.ds.AVArray &&
+				ch.options.arraySwapOptions &&
+				ch.options.arraySwapOptions.use === true)
+			{
+				// remove selected class before swapping, in case the classes are swapped
+				options.from.removeClass(options.fromIndex, ch.options.selectedClass);
+				options.from.swap(options.fromIndex, options.toIndex, ch.options.arraySwapOptions);
+			} else {
+				ch.jsav.effects.swapValues.apply(this, args);
+			}
+			break;
+		case "toss":
+			//remove value from "from structure"
+			if (typeof options.fromIndex === "number") {
+				//remove from array
+				ch.getDs(ch.selStruct.value()).value(ch.selIndex.value(), "");
+			}
+			break;
+		}
+
+		if (ch.options.removeNodes &&
+			$.inArray(options.effect, ["move", "toss"]) !== - 1 &&
+			typeof options.fromIndex === "undefined")
+			{
+			//remove empty node
+			if (ch.getDs(ch.selStruct.value()) instanceof JSAV._types.ds.List) {
+				//remove node from list
+				var list = ch.getDs(ch.selStruct.value());
+				var i;
+				for (i = 0; i < list.size(); i++) {
+					if (list.get(i) === options.from) {
+						list.remove(i);
+						break;
+					}
+				}
+			} else {
+				//TODO: check if this works
+				options.from.remove();
+			}
+			//refresh structures with nodes
+			ch.getDs(ch.selStruct.value()).layout();
+		}
+	}
+
+	//creates an argument array for moveValue/copyValue/swapValue.apply()
+	function valueEffectArguments(options) {
+		if (typeof options.fromIndex !== "undefined") {
+			if (typeof options.toIndex !== "undefined") {
+				//array to array
+				return [options.from, options.fromIndex, options.to, options.toIndex];
+			} else {
+				//array to node
+				return [options.from, options.fromIndex, options.to];
+			}
+		} else {
+			if (typeof options.toIndex !== "undefined") {
+				//node to array
+				return [options.from, options.to, options.toIndex];
+			} else {
+				//node to node
+				return [options.from, options.to];
+			}
+		}
+	}
+
+	if (window) {
+		window.ClickHandler = ClickHandler;
+	}
+}(jQuery));

--- a/testbench/OpenDSA/AV/Development/commonTriePRO.html
+++ b/testbench/OpenDSA/AV/Development/commonTriePRO.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+  <title>Common Trie</title>
+  <link rel="stylesheet" href="../../JSAV/css/JSAV.css" type="text/css" />
+  <link rel="stylesheet" href="../../lib/odsaAV-min.css" type="text/css" />
+  <link rel="stylesheet" href="proficiency.css" type="text/css" />
+  <style>
+    .jsavtreenode {
+      cursor: pointer;
+    }
+    .jsavtreenode {
+      width: 30px;
+      height: 30px;
+      border-radius: 15px;
+
+    }
+    .jsavtreenode .jsavvalue{
+      height: 30px;
+      font-size: 14px;
+    }
+    .jsavedgelabel {
+      background-color: transparent;
+      text-shadow: 0 0 4px #fff;
+    }
+    .jsavcanvas {
+      overflow: auto;
+      height: 550px;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="jsavcontainer">
+    <h1 class="exerciseTitle"></h1>
+    <p class="instructLabel"></p>
+    <p class="instructions"></p>
+    <p align="center" class="jsavexercisecontrols"></p>
+    <p class="jsavoutput jsavline"></p>
+    <p class="jsavscore"></p>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js"></script>
+  <script src="../../JSAV/lib/jquery.transit.js"></script>
+  <script src="../../JSAV/lib/raphael.js"></script>
+  <script src="../../JSAV/build/JSAV-min.js"></script>
+  <script src="../../JSAV/extras/stack.js"></script>
+  <script src="../../lib/odsaUtils-min.js"></script>
+  <script src="../../lib/odsaAV-min.js"></script>
+  <script src="ClickHandler.js"></script>
+  <script src="commonTriePRO.js"></script>
+</body>
+</html>

--- a/testbench/OpenDSA/AV/Development/commonTriePRO.js
+++ b/testbench/OpenDSA/AV/Development/commonTriePRO.js
@@ -1,0 +1,201 @@
+﻿/* global ODSA, PARAMS */
+(function ($) {
+  "use strict";
+  // AV variables
+  var initialData = [],
+      size = PARAMS.size ? parseInt(PARAMS.size, 10) : 7,
+      length = PARAMS.length ? parseInt(PARAMS.length, 10) : 4,
+      stack,
+      commonTrie,
+      $insertLabel,
+      $trieLabel,
+      $nextButton,
+
+      // configurations
+      config = ODSA.UTILS.loadConfig({av_container: "jsavcontainer"}),
+      interpret = config.interpreter,
+      code = config.code,
+      codeOptions = {after: {element: $(".instructions")}, visible: true},
+
+      // Create a JSAV instance
+      av = new JSAV("jsavcontainer", {autoresize: false});
+
+  av.recorded(); // we are not recording an AV with an algorithm
+
+  av.code($.extend(codeOptions, code));
+
+  function initialize() {
+
+    if (stack) {
+      stack.clear();
+    }
+
+    if (commonTrie) {
+      commonTrie.clear();
+    }
+
+    // generate input
+    initialData = generateArrayWithStrings(size, length);
+
+    stack = av.ds.stack(initialData, {center: true});
+    stack.click(function () {
+      stack.removeFirst();
+      stack.layout();
+    });
+
+    commonTrie = av.ds.tree({center: false, visible: true, autoresize: false, nodegap: 15});
+    commonTrie.element.addClass("jsavcenter");
+    showChildren(commonTrie.root());
+    commonTrie.click(clickHandler);
+    commonTrie.layout();
+
+    // remove all old labels
+    av.container.find(".exerciseElement").remove();
+
+    // create new labels
+    $insertLabel = $("<p class='exerciseElement'>" + interpret("av_insert") + "</p>");
+    $trieLabel = $("<p class='exerciseElement'>" + interpret("av_common_trie") + "</p>");
+
+    // style the labels
+    $insertLabel.add($trieLabel)
+      .css("text-align", "center")
+      .css("font-weight", "bold");
+
+    // insert the labels
+    $insertLabel.insertBefore(stack.element);
+    $trieLabel.insertBefore(commonTrie.element);
+
+    // create button and position it on the right side of the stack
+    $nextButton = $('<input id="next" type="button" value="' + interpret("av_next") + '" class="exerciseElement jsavcenter" />').insertAfter(stack.element);
+    $nextButton.position({my: "left", at: "right", of: stack.element});
+    $nextButton.css({left: "+=50"});
+    $nextButton.click(function () {
+      stack.removeFirst();
+      stack.layout();
+    });
+
+    return commonTrie;
+  }
+
+
+  function modelSolution(jsav) {
+    //higlights and unhighlights a path between root and node
+    function highlightPath(root, node, undo) {
+      var n = node;
+      var css;
+      if (undo) {
+        css = {"stroke-width": "1", "stroke": "black"};
+      } else {
+        css = {"stroke-width": "4", "stroke": "blue"};
+      }
+      while (n !== root) {
+        n.edgeToParent().css(css);
+        n = n.parent();
+      }
+    }
+
+    var msStack = jsav.ds.stack(initialData, {center: true});
+
+    var msTree = jsav.ds.tree({center: true, visible: true, autoresize: false, nodegap: 15});
+
+    showChildren(msTree.root());
+    // msTree.element.addClass("jsavcenter");
+    msTree.element.css("margin-top", 30);
+    msTree.layout();
+
+    jsav.displayInit();
+
+    while (msStack.first()) {
+      var str = msStack.first().value();
+      str = str.substring(1, str.length - 1);
+      var node = msTree.root();
+      jsav.umsg(interpret("av_add_str"), {fill: {str: str}});
+      jsav.step();
+
+      for (var i = 0; i < str.length; i++) {
+        node = node.child("abc".indexOf(str.charAt(i)));
+        highlightPath(msTree.root(), node);
+        if (node.hasClass("emptynode")) {
+          showChildren(node);
+          msTree.layout();
+          jsav.step();
+        }
+      }
+      if (!node.value()) {
+        node.value(true);
+        node.addClass("greenbg");
+        jsav.umsg(interpret("av_set_true"), {fill: {str: str}});
+      } else {
+        jsav.umsg(interpret("av_already_true"), {fill: {str: str}});
+      }
+      jsav.step();
+      highlightPath(msTree.root(), node, true);
+
+      msStack.removeFirst();
+      msStack.layout();
+    }
+    jsav.step();
+
+    return msTree;
+  }
+
+
+  function showChildren(node) {
+    node.removeClass("emptynode");
+    node.value(false);
+    // add empty node children
+    node.child(0, "", {edgeLabel: "a"})
+        .child(1, "", {edgeLabel: "b"})
+        .child(2, "", {edgeLabel: "c"});
+    node.child(0).addClass("emptynode");
+    node.child(1).addClass("emptynode");
+    node.child(2).addClass("emptynode");
+    // call the layout function
+    commonTrie.layout();
+  }
+
+  function clickHandler() {
+    if (this.hasClass("emptynode")) {
+      showChildren(this);
+      // grade the step
+      exercise.gradeableStep();
+    } else {
+      // toggle true/false
+      this.value(!this.value());
+      if (this.value()) {
+        this.addClass("greenbg");
+      } else {
+        this.removeClass("greenbg");
+      }
+    }
+  }
+
+  // Generates an array of the size given in the first argument.
+  // maxLength is given as the second argument.
+  // Strings consist of the letters a, b and c and are surronded
+  // by quotes (quotes not include in length). There is always
+  // exactly one string which is empty.
+  function generateArrayWithStrings(size, maxLength) {
+    var result = [];
+
+    for (var i = 0; i < size; i++) {
+      var length = 1 + Math.floor(Math.random() * maxLength);
+      var str = "\"";
+      for (var c = 0; c < length; c++) {
+        str += ["a", "b", "c"][Math.floor(Math.random() * 3)];
+      }
+      str += "\"";
+      result.push(str);
+    }
+
+    result[1 + Math.floor(Math.random() * (size - 1))] = "\"\"";
+
+    return result;
+  }
+
+  var exercise = av.exercise(modelSolution, initialize,
+                             { feedback: "atend", grader: "finalStep",
+                               modelDialog: {width: 780}});
+  exercise.reset();
+
+}(jQuery));

--- a/testbench/OpenDSA/AV/Development/commonTriePRO.js
+++ b/testbench/OpenDSA/AV/Development/commonTriePRO.js
@@ -195,7 +195,7 @@
 
   var exercise = av.exercise(modelSolution, initialize,
                              { feedback: "atend", grader: "finalStep",
-                               modelDialog: {width: 780}});
+                               modelDialog: {"minWidth": 780, "width": ""}});
   exercise.reset();
 
 }(jQuery));

--- a/testbench/OpenDSA/AV/Development/commonTriePRO.json
+++ b/testbench/OpenDSA/AV/Development/commonTriePRO.json
@@ -1,0 +1,32 @@
+{
+  "translations" :{
+    "en": {
+      ".exerciseTitle": "Common Trie",
+      ".instructLabel": "Instructions:",
+      ".instructions": "Insert the strings in the stack to the common trie. Click on an empty node to initialize it as false and show empty nodes as its children. The boolean value of a node can be changed by clicking on the node. Click the <strong>Next</strong> button to show the next value in the stack. When all values have been inserted, click <strong>Grade</strong>.",
+      "av_insert": "Insert",
+      "av_common_trie": "Common Trie",
+      "av_next": "Next",
+      "av_add_str": "Adding string \"{str}\"",
+      "av_set_true": "The node corresponding to \"{str}\" is set to true",
+      "av_already_true": "The node corresponding to \"{str}\" has already been set to true. The string is already included in the tree."
+    },
+    "fi": {
+      ".exerciseTitle": "Merkkijonopuu",
+      ".instructLabel": "Ohjeet:",
+      ".instructions": "Lisää pinossa annetut merkkijonot merkkijonopuuhun. Klikkaa tyhjää solmua alustaaksesi sen ja aktivoidaksesi sen alipuun. Solmun true/false -bitin arvon voi vaihtaa klikkaamalla. Kun merkkijono on lisätty seuraavan merkkijonon saa näkyviin painamalla <strong>Seuraava</strong>-nappia. Paina <strong>Arvostele</strong>-nappia kun kaikki arvot on lisätty puuhun.",
+      "av_insert": "Lisää",
+      "av_common_trie": "Merkkijonopuu",
+      "av_next": "Seuraava",
+      "av_add_str": "Lisätään merkkijono \"{str}\"",
+      "av_set_true": "Merkkijonoa \"{str}\" vastaavan solmun arvo muutetaan true:ksi",
+      "av_already_true": "Merkkijonoa \"{str}\" vastaavan solmun arvo on jo true, eli merkkijono on jo lisätty puuhun."
+    }
+  },
+  "code": {
+    "pseudo": {
+      "url": "../../SourceCode/Pseudo/Binary/CommonTrie.txt",
+      "tags": {}
+    }
+  }
+}

--- a/testbench/OpenDSA/AV/Development/trie.css
+++ b/testbench/OpenDSA/AV/Development/trie.css
@@ -1,0 +1,20 @@
+.jsavtreenode {
+  cursor: pointer;
+}
+.jsavtree {
+  margin-top: 30px;
+}
+.jsavstack {
+  margin-top: 30px;
+}
+.jsavlabel {
+  border: 1px solid #eca;
+  border-radius: 3px;
+  padding: 1px 3px;
+  background-color: #fe8;
+  color: #975;
+  position: absolute;
+  z-index: 101;
+  line-height: normal;
+  font-size: medium;
+}

--- a/testbench/OpenDSA/JSAV/extras/stack.css
+++ b/testbench/OpenDSA/JSAV/extras/stack.css
@@ -1,0 +1,11 @@
+.jsavstack {
+  position: relative;
+  background-color: inherit;
+}
+.jsavstacknode {
+  position: absolute;
+  border-radius: 5px;
+  width: 45px;
+  height: 45px;
+  z-index: 100;
+}

--- a/testbench/OpenDSA/JSAV/extras/stack.js
+++ b/testbench/OpenDSA/JSAV/extras/stack.js
@@ -1,0 +1,171 @@
+(function ($) {
+  "use strict";
+  if (typeof JSAV === "undefined") { return; }
+
+  var Stack = function (jsav, values, options) {
+    this.jsav = jsav;
+    if (!$.isArray(values)) {
+      options = values;
+      values = [];
+    }
+    this.options = $.extend({visible: true, xtransition: 10, ytransition: -5, autoresize: true}, options);
+    var el = this.options.element || $("<div/>");
+    el.addClass("jsavstack");
+    for (var key in this.options) {
+      var val = this.options[key];
+      if (this.options.hasOwnProperty(key) && typeof(val) === "string" || typeof(val) === "number" || typeof(val) === "boolean") {
+        el.attr("data-" + key, val);
+      }
+    }
+    if (!this.options.element) {
+      $(jsav.canvas).append(el);
+    }
+    this.element = el;
+    this.element.attr({"id": this.id()});
+    if (this.options.autoresize) {
+      el.addClass("jsavautoresize");
+    }
+    for (var i = values.length; i--; ) {
+      this.addFirst(values[i]);
+    }
+    if (values.length > 0) {
+      this.layout();
+    }
+    JSAV.utils._helpers.handlePosition(this);
+    JSAV.utils._helpers.handleVisibility(this, this.options);
+  };
+  JSAV.utils.extend(Stack, JSAV._types.ds.List);
+  var stackproto = Stack.prototype;
+
+  stackproto.newNode = function (value, options) {
+    return new StackNode(this, value, $.extend({first: false}, this.options, options));
+  };
+
+  stackproto.layout = function (options) {
+    var layoutAlg = $.extend({}, this.options, options).layout || "_default";
+    return this.jsav.ds.layout.stack[layoutAlg](this, options);
+  };
+
+  var StackNode = function (container, value, options) {
+    this.jsav = container.jsav;
+    this.container = container;
+    this._next = options.next;
+    this._value = value;
+    this.options = $.extend(true, {visible: true}, options);
+    var el = $("<div><span class='jsavvalue'>" + this._valstring(value) + "</span></div>"),
+      valtype = typeof(value);
+    if (valtype === "object") { valtype = "string"; }
+    this.element = el;
+    el.addClass("jsavnode jsavstacknode")
+        .attr({"data-value": value, "id": this.id(), "data-value-type": valtype })
+        .data("node", this);
+    if ("first" in options && options.first) {
+      this.container.element.prepend(el);
+    } else {
+      this.container.element.append(el);
+    }
+    JSAV.utils._helpers.handleVisibility(this, this.options);
+  };
+  JSAV.utils.extend(StackNode, JSAV._types.ds.ListNode);
+  var stacknodeproto = StackNode.prototype;
+
+
+  stacknodeproto._setnext = JSAV.anim(function (newNext, options) {
+    var oldNext = this._next;
+    this._next = newNext;
+    return [oldNext];
+  });
+
+  stacknodeproto.zIndex = JSAV.anim(function (index) {
+    var oldVal = ~~this.element.css("z-index"),
+        node = this;
+    if (this.jsav._shouldAnimate()) { // only animate when playing, not when recording
+      $({ z: oldVal }).animate({ z: index }, {
+          step: function() {
+              node.element.css('zIndex', ~~this.z);
+          },
+          duration: this.jsav.SPEED
+      });
+    } else {
+      this.element.css("z-index", index);
+    }
+    return [oldVal];
+  });
+
+  var stackLayout = function (stack, options) {
+    var curNode = stack.first(),
+        prevNode,
+        pos = {},
+        xTrans = stack.options.xtransition,
+        yTrans = stack.options.ytransition,
+        opts = $.extend({}, stack.options, options),
+        width = 0,
+        height = 0,
+        left = 0,
+        posData = [],
+        zPos;
+
+    while (curNode) {
+      if (prevNode) {
+        pos = {
+          left: pos.left + xTrans,
+          top: pos.top + yTrans
+        };
+        zPos -= 1;
+        width += Math.abs(xTrans);
+        if ((yTrans < 0 && pos.top < posData[0].nodePos.top) || (yTrans > 0 && pos.top > posData[0].nodePos.top)) {
+          height += Math.abs(yTrans);
+        }
+        if (stack.options.ytransition < 0) {
+          yTrans += 1;
+        }
+      } else {
+        pos = {
+          left: (xTrans < 0? stack.size(): 0) * -xTrans,
+          top: (yTrans < 0? Math.min(stack.size(), -yTrans): 0) * -(yTrans - 1)/2
+        };
+        zPos = stack.size();
+        width = curNode.element.outerWidth();
+        height = curNode.element.outerHeight();
+      }
+      posData.push({node: curNode, nodePos: pos, zPos: zPos});
+
+      prevNode = curNode;
+      curNode = curNode.next();
+    }
+    if (stack.size() === 0) {
+      var tmpNode = stack.newNode("");
+      width = tmpNode.element.outerWidth();
+      height = tmpNode.element.outerHeight();
+      tmpNode.clear();
+    }
+
+    if (stack.options.center) {
+      left = ($(stack.jsav.canvas).width() - width) / 2;
+    } else {
+      left = stack.element.position().left;
+    }
+
+    if (!opts.boundsOnly) {
+      // ..update stack size and position..
+      stack.css({width: width, height: height, left: left});
+      // .. and finally update the node positions
+      // doing the size first makes the animation look smoother by reducing some flicker
+      for (var i = 0; i < posData.length; i++) {
+        var posItem = posData[i];
+        posItem.node.zIndex(posItem.zPos);
+        posItem.node.css(posItem.nodePos);
+      }
+    }
+    return { width: width, height: height, left: left, top: stack.element.position().top };
+  };
+
+  JSAV.ext.ds.layout.stack = {
+    "_default": stackLayout
+  };
+
+  JSAV.ext.ds.stack = function(values, options) {
+    return new Stack(this, values, options);
+  };
+
+}(jQuery));


### PR DESCRIPTION
Resolve issue https://github.com/Aalto-LeTech/jsav-exercise-recorder/issues/140.
The exercise was intialised with a fixed-width for the model answer.
However, the graph can be wider than that. As such, the initialisation
has been changed to have a minWidth of 780px rather than a width of
780px. To avoid JSAV calculating a width that is relative to the
screen size, we pass the empty string to the width parameter.