### PR TITLE
Prim and Dijkstra improvements: Code in unscaffolded, legends in all

### DIFF
--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.css
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.css
@@ -1,7 +1,13 @@
 #container {
-  width: 800px;
+  /* width: 800px; */
   height: 595px;
 }
+
+.codeblock {
+  float: left;
+  margin: 1em;
+}
+
 .jsavline {
   height: 45px;
   margin: 0 0 0 20px;

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.css
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.css
@@ -1,11 +1,22 @@
 #container {
   /* width: 800px; */
-  height: 595px;
+  min-height: 595px;
 }
 
 .codeblock {
   float: left;
   margin: 1em;
+}
+
+.legend {
+  background-color: #FFFFFF; 
+  /* border: 1px solid; */
+  height: 115px;
+  margin-left: 40px;
+}
+
+.subheading {
+  margin-left: 40px;
 }
 
 .jsavline {
@@ -40,4 +51,14 @@
 .jsavautoresize .jsavnode {
   min-width: 45px;
   min-height: 45px;
+}
+
+.edge {
+  stroke-width: 10;
+  stroke: #d1c39d;
+}
+
+.edge.spanning {
+  stroke: #ffe000;
+  stroke-width: 16px;
 }

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.html
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.html
@@ -30,7 +30,9 @@
         <!-- This class of codeblock with child of class code are used to float
         the pseudocode to the left side of the screen. The inner class code is
         needed, as JSAV can only append to something, not add inside :) -->
-        <div class="codeblock" style="float: left;"><div class="code"> </div></div>
+        <div class="codeblock" style="float: left;">
+          <div class="code"> </div>
+        </div>
         <div class="jsavcanvas">
           <p id="procontrols">
             <span class="jsavscore"></span>

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.html
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.html
@@ -25,9 +25,13 @@
         </tr>
       </table>
       <form class="avcontainer">
+        <p class="instructLabel"></p>
+        <p class="instructions"></p>
+        <!-- This class of codeblock with child of class code are used to float
+        the pseudocode to the left side of the screen. The inner class code is
+        needed, as JSAV can only append to something, not add inside :) -->
+        <div class="codeblock" style="float: left;"><div class="code"> </div></div>
         <div class="jsavcanvas">
-          <p class="instructLabel"></p>
-          <p class="instructions"></p>
           <p id="procontrols">
             <span class="jsavscore"></span>
           </p>

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.js
@@ -29,6 +29,21 @@
     pseudo = jsav.code();
   }
 
+   //Add the legend to the exercise
+   const edge = '<path d="M25,30L75,30" class="edge"></path>'
+              +'<text x="90" y="35">' + interpret("graph_edge") + '</text>'
+    const spanningEdge = '<path d="M25,80L75,80" class="edge spanning">' 
+                       + '</path><text x="90" y="85">'
+                       + interpret("spanning_edge") + '</text>'
+    const legend = "<div class='subheading'><center><strong>" 
+                 + interpret("legend")
+                 + "</center></strong></div>" 
+                 + "<div class='legend'>"
+                 + "<svg version='1.1' xmlns='http://www.w3.org/ 2000/svg'> "
+                 + edge + spanningEdge
+                 + " </svg></div>"
+    $(".codeblock").append(legend)
+
   function init() {
     // Create a JSAV graph instance
     if (graph) {

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.js
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.js
@@ -13,12 +13,21 @@
       config = ODSA.UTILS.loadConfig(),
       interpret = config.interpreter,
       settings = config.getSettings(),
+      code = config.code,
+      pseudo,
       jsav = new JSAV($('.avcontainer'), {settings: settings}),
       exerciseInstance,
       lastLinearTransform = -1, // for generateInstance()
       debug = false; // produces debug prints to console
 
   jsav.recorded();
+
+  if (code) {
+    pseudo = jsav.code($.extend({after: {element: $(".code")}}, code));
+    pseudo.highlight(8)
+  } else {
+    pseudo = jsav.code();
+  }
 
   function init() {
     // Create a JSAV graph instance
@@ -40,6 +49,9 @@
     graph.layout();
     graph.nodes()[exerciseInstance.startIndex].addClass("marked"); // mark the 'A' node
     jsav.displayInit();
+    // Remove the initially calculated min-width to ensure that the graph is 
+    // to the right of the code block. 
+    $(".jsavcanvas").css("min-width", "")
     return graph;
   }
 

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.json
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.json
@@ -13,7 +13,10 @@
       "av_ms_update_distances": "Update {node}'s neighbors distances. For updated nodes, set the parent node to {node}",
       "#help": "Help",
       "#about": "About",
-      "reset": "New Exercise"
+      "reset": "New Exercise",
+      "legend": "Legend",
+      "graph_edge": "Graph edge",
+      "spanning_edge": "Spanning tree edge"
     },
     "fi": {
       ".avTitle": "Dijkstran algoritmi",
@@ -28,7 +31,10 @@
       "av_ms_update_distances": "Päivitetään etäisyyksiä {node}-solmun naapureihin. Päivitetyille solmuille asetetaan lähin solmu {node}:ksi.",
       "#help": "Ohje",
       "#about": "Lisätietoa",
-      "reset": "Uusi Tehtävä"
+      "reset": "Uusi Tehtävä",
+      "legend": "Selite",
+      "graph_edge": "Verkon särmä",
+      "spanning_edge": "Virityspuun särmä"
     }
   },
   "params": {

--- a/testbench/OpenDSA/AV/Development/DijkstraPE-research.json
+++ b/testbench/OpenDSA/AV/Development/DijkstraPE-research.json
@@ -4,7 +4,7 @@
       ".avTitle": "Dijkstra's Algorithm Proficiency Exercise",
       "av_Authors": "Mohammed Fawzi, Kasper Hellström",
       ".instructLabel": "Instructions:",
-      ".instructions": "Reproduce the behavior of Dijkstra's Algorithm for the given graph below. Click on the <strong>edges</strong> in the order they are traversed by the algorithm. Start with Node A. In case of similar costs, add nodes alphabetically.",
+      ".instructions": "Reproduce the behavior of Dijkstra's Algorithm for the given graph below. Click on the <strong>edges</strong> in the order they are traversed by the algorithm. Start with Node A.",
       "av_ms_shortest": "Shortest paths from A.",
       "av_ms_select_a": "Start by selecting node A",
       "av_ms_select_node": "Select {node}, since it has the shortest distance from A.",
@@ -19,7 +19,7 @@
       ".avTitle": "Dijkstran algoritmi",
       "av_Authors": "Mohammed Fawzi, Kasper Hellström",
       ".instructLabel": "Ohjeet:",
-      ".instructions": "Lisää särmät virityspuuhun Dijkstran algoritmin antamassa järjestyksessä. Aloita läpikäynti solmusta A. Klikkaa <strong>särmiä</strong> lisätäksesi ne virityspuuhun. Jos kustannus on sama, käytä aakkosjärjestystä.",
+      ".instructions": "Lisää särmät virityspuuhun Dijkstran algoritmin antamassa järjestyksessä. Aloita läpikäynti solmusta A. Klikkaa <strong>särmiä</strong> lisätäksesi ne virityspuuhun.",
       "av_ms_shortest": "Lyhyin reitti A:sta.",
       "av_ms_select_a": "Aloitetaan valitsemalla solmu A.",
       "av_ms_select_node": "Valitaan {node}, koska sillä on lyhin etäisyys A:han.",
@@ -34,5 +34,10 @@
   "params": {
     "JXOP-feedback": "continuous",
     "JXOP-fixmode": "fix"
+  }, 
+  "code": {
+    "Pseudo": {
+      "url": "../../SourceCode/Pseudo/Graphs/Dijkstra.txt"
+    }
   }
 }

--- a/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.css
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.css
@@ -94,3 +94,41 @@
   max-width: none !important;
   min-width: 70px !important;
 }
+
+.legend {
+  height: 250px;
+  width: 250px;
+  border: 1px solid;
+  background-color: #ffffff;
+}
+
+.edge {
+  stroke-width: 10;
+  stroke: #d1c39d;
+}
+
+.edge.spanning {
+  stroke: #ffe000;
+  stroke-width: 16px;
+}
+
+.edge.queued {
+  stroke: #d59f0d;
+}
+
+.flex {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: center;
+}
+
+.flex > div {
+  margin-left: 20px;
+  margin-right: 20px;
+}
+
+
+.green {
+  color: #4ebd44;
+  font-weight: bold;
+}

--- a/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.js
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.js
@@ -860,11 +860,37 @@
       minheap.clear();
       $(".prioqueue").remove();
       $(".bintree").remove();
+      $(".flex").remove();
     }
     heapsize = heapsize.value(0);
-    $(".jsavcanvas").append("<div class='prioqueue'><strong>"
+    const edge = '<path d="M25,30L75,30" class="edge"></path>'
+               +'<text x="90" y="35">' + interpret("graph_edge") + '</text>'
+    const queuedEdge = '<path d="M25,80L75,80" class="edge queued">'
+                     + '</path><text x="90" y="85">'
+                     + interpret("enqueued_edge") + '</text>'
+    const spanningEdge = '<path d="M25,130L75,130" class="edge spanning">' 
+                       + '</path><text x="90" y="135">'
+                       + interpret("spanning_edge") + '</text>'
+    const node = '<circle cx="50" cy="200" r="22" fill="none" stroke="black" />'
+               + '<text x="45" y="195">5</text>'
+               + '<text x="35" y="213"> C (B)</text>'
+               + '<text x="90" y="190">' + interpret("node_explanation") + '</text>'
+    const legend = "<div><div class='prioqueue'><strong>" 
+                 + interpret("legend")
+                 + "</strong></div>" 
+                 + "<div class='legend'><svg version='1.1' xmlns='http://www.w3.org/2000/svg'> "
+                 + edge + queuedEdge + spanningEdge + node
+                 + " </svg></div></div>"
+    $(".jsavcanvas").append("<div class='flex'>"
+        + "<div class='left'><div class='prioqueue'><strong>"
         + interpret("priority_queue")
-        + "</strong></div><div class='bintree'></div>");
+        + "</strong></div><div class='bintree'></div></div>" 
+        + legend
+        + "</div>");
+
+    // Explicitly set the size of this one, otherwise it defaults to
+    // the size that the graph has. 
+    $(".legend > svg").css({'height': '250px', 'width': '250px'})
     minheap = jsav.ds.binarytree({relativeTo: $(".bintree"),
                                   myAnchor: "center center"});
     minheap.layout()
@@ -922,9 +948,9 @@
     table = jsav.ds.matrix([labelArr, distanceArr, parentArr],
                            {style: "table",
                            width: width,
-                           relativeTo: $(".jsavbinarytree"),
+                           relativeTo: $(".flex"),
                            myAnchor: "center top",
-                           top: "150px"});
+                           top: "150px"}); //Place below the bin tree
   }
 
   /**

--- a/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.json
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE-scaffolded.json
@@ -25,7 +25,12 @@
       "node": "Node",
       "distance": "Distance",
       "parent": "Parent",
-      "edge": "Edge"
+      "edge": "Edge",
+      "legend": "Legend",
+      "node_explanation": "<tspan>C has distance 5 from A</tspan><tspan x='90' dy='20'>with parent B</tspan>",
+      "graph_edge": "Graph edge",
+      "enqueued_edge": "Enqueued edge",
+      "spanning_edge": "Spanning tree edge"
     },
     "fi": {
       ".avTitle": "Primin algoritmi",
@@ -52,7 +57,12 @@
       "node": "Solmu",
       "distance": "Etäisyys",
       "parent": "Vanhempi",
-      "edge": "Särmä"
+      "edge": "Särmä",
+      "legend": "Selite",
+      "node_explanation": "<tspan>C:n etäisyys A:sta on 5</tspan><tspan x='90' dy='20'>vanhemman B kautta</tspan>",
+      "graph_edge": "Verkon särmä",
+      "enqueued_edge": "Jonossa oleva särmä",
+      "spanning_edge": "Virityspuun särmä"
     }
   },
   "params": {

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.css
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.css
@@ -1,5 +1,5 @@
 #container {
-  width: 800px;
+  /* width: 800px; */
   height: 595px;
 }
 .jsavline {

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.css
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.css
@@ -1,7 +1,19 @@
 #container {
   /* width: 800px; */
-  height: 595px;
+  min-height: 595px;
 }
+
+.legend {
+  background-color: #FFFFFF; 
+  /* border: 1px solid; */
+  height: 115px;
+  margin-left: 40px;
+}
+
+.subheading {
+  margin-left: 40px;
+}
+
 .jsavline {
   height: 45px;
   margin: 0 0 0 20px;
@@ -34,4 +46,14 @@
 .jsavautoresize .jsavnode {
   min-width: 45px;
   min-height: 45px;
+}
+
+.edge {
+  stroke-width: 10;
+  stroke: #d1c39d;
+}
+
+.edge.spanning {
+  stroke: #ffe000;
+  stroke-width: 16px;
 }

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.html
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.html
@@ -30,7 +30,9 @@
         <!-- This class of codeblock with child of class code are used to float
         the pseudocode to the left side of the screen. The inner class code is
         needed, as JSAV can only append to something, not add inside :) -->
-        <div class="codeblock" style="float: left;"><div class="code"> </div></div>
+        <div class="codeblock" style="float: left;">
+          <div class="code"></div>
+        </div>
         <div class="jsavcanvas">
           <p id="procontrols">
             <span class="jsavscore"></span>

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.html
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.html
@@ -25,9 +25,13 @@
         </tr>
       </table>
       <form class="avcontainer">
+        <p class="instructLabel"></p>
+        <p class="instructions"></p>
+        <!-- This class of codeblock with child of class code are used to float
+        the pseudocode to the left side of the screen. The inner class code is
+        needed, as JSAV can only append to something, not add inside :) -->
+        <div class="codeblock" style="float: left;"><div class="code"> </div></div>
         <div class="jsavcanvas">
-          <p class="instructLabel"></p>
-          <p class="instructions"></p>
           <p id="procontrols">
             <span class="jsavscore"></span>
           </p>

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.js
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.js
@@ -4,6 +4,8 @@
   var exercise,
       graph,
       config = ODSA.UTILS.loadConfig(),
+      code = config.code, 
+      pseudo,
       interpret = config.interpreter,
       settings = config.getSettings(),
       jsav = new JSAV($('.avcontainer'), {settings: settings});
@@ -11,6 +13,13 @@
   var debug = false; // produces debug prints to console
 
   jsav.recorded();
+
+  if (code) {
+    pseudo = jsav.code($.extend({after: {element: $(".code")}}, code));
+    pseudo.highlight(8)
+  } else {
+    pseudo = jsav.code();
+  }
 
   function init_old() {
     // create the graph
@@ -92,6 +101,7 @@
     graph.layout();
     graph.nodes()[0].addClass("marked"); // mark the 'A' node
     jsav.displayInit();
+    $(".jsavcanvas").css("min-width", "")
     return graph;
   }
 

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.js
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.js
@@ -14,12 +14,28 @@
 
   jsav.recorded();
 
+  //Add the code block to the exercise. 
+
   if (code) {
     pseudo = jsav.code($.extend({after: {element: $(".code")}}, code));
     pseudo.highlight(8)
   } else {
     pseudo = jsav.code();
   }
+
+  //Add the legend to the exercise
+  const edge = '<path d="M25,30L75,30" class="edge"></path>'
+               +'<text x="90" y="35">' + interpret("graph_edge") + '</text>'
+  const spanningEdge = '<path d="M25,80L75,80" class="edge spanning">' 
+                      + '</path><text x="90" y="85">'
+                      + interpret("spanning_edge") + '</text>'
+  const legend = "<div class='subheading'><center><strong>" 
+                + interpret("legend")
+                + "</center></strong></div>" 
+                + "<div class='legend'><svg version='1.1' xmlns='http://www.w3.org/2000/svg'> "
+                + edge + spanningEdge
+                + " </svg></div>"
+  $(".codeblock").append(legend)
 
   function init_old() {
     // create the graph

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.json
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.json
@@ -34,5 +34,10 @@
   "params": {
     "JXOP-feedback": "continuous",
     "JXOP-fixmode": "fix"
+  },
+  "code": {
+    "Pseudo": {
+      "url": "../../SourceCode/Pseudo/Graphs/Prim.txt"
+    }
   }
 }

--- a/testbench/OpenDSA/AV/Development/PrimAVPE.json
+++ b/testbench/OpenDSA/AV/Development/PrimAVPE.json
@@ -13,7 +13,10 @@
       "av_ms_update_distances": "Update distance to {node}'s neighbors. For updated nodes, set closest node to {node}",
       "#help": "Help",
       "#about": "About",
-      "reset": "New Exercise"
+      "reset": "New Exercise",
+      "legend": "Legend",
+      "graph_edge": "Graph edge",
+      "spanning_edge": "Spanning tree edge"
     },
     "fi": {
       ".avTitle": "Primin algoritmi",
@@ -28,7 +31,10 @@
       "av_ms_update_distances": "Päivitetään etäisyyksiä {node}-solmun naapureihin. Päivitetyille solmuille asetetaan lähin solmu {node}:ksi.",
       "#help": "Ohje",
       "#about": "Lisätietoa",
-      "reset": "Uusi Tehtävä"
+      "reset": "Uusi Tehtävä",
+      "legend": "Selite",
+      "graph_edge": "Verkon särmä",
+      "spanning_edge": "Virityspuun särmä"
     }
   },
   "params": {

--- a/testbench/OpenDSA/SourceCode/Pseudo/Graphs/Dijkstra.txt
+++ b/testbench/OpenDSA/SourceCode/Pseudo/Graphs/Dijkstra.txt
@@ -1,0 +1,14 @@
+Algorithm Dijkstra(G, source)
+    foreach v in V:
+        distance[v] := infinity
+        previous[v] := undefined
+    distance[source] := 0
+    insert source into Q
+    while Q is not empty:
+        u := remove v from Q with smallest distance[]
+        for each (u, v) in E:
+            if (dist := distance[u] + distance(u, v)) < distance[v]:
+                distance[v] := dist
+                previous[v] := u
+                update or insert v into Q
+    return previous[]

--- a/testbench/OpenDSA/SourceCode/Pseudo/Graphs/Prim.txt
+++ b/testbench/OpenDSA/SourceCode/Pseudo/Graphs/Prim.txt
@@ -1,0 +1,14 @@
+Algorithm Prim(G, source)
+    foreach v in V:
+        distance[v] := infinity
+        previous[v] := undefined
+    distance[source] := 0
+    insert source into Q
+    while Q is not empty:
+        u := remove v from Q with smallest distance[]
+        for each (u, v) in E:
+            if (dist := distance(u, v)) < distance[v]:
+                distance[v] := dist
+                previous[v] := u
+                update or insert v into Q
+    return previous[]


### PR DESCRIPTION
Upon Archie's request, the unscaffolded Dijkstra and Prim now have the code on the left side of the exercise. 
Additionally, all Dijkstra and Prim versions now have a legend. 