### PR TITLE
Fix BFS exercise by removing typo

### DIFF
--- a/testbench/OpenDSA/AV/Development/graphBFSPE.js
+++ b/testbench/OpenDSA/AV/Development/graphBFSPE.js
@@ -247,7 +247,7 @@
   // Process About button: Pop up a message with an Alert
   function about() {
     window.alert(ODSA.AV.aboutstring(interpret(".avTitle"), interpret("av_Authors")));
-  }modeljsav
+  }
 
   exercise = jsav.exercise(model, init, {
     compare: {class: "visited"},


### PR DESCRIPTION
The typo caused BFS exercise to not load correctly.